### PR TITLE
:white_check_mark: Validate emitted SQL against real PostgreSQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,22 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sqld_validate
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -21,5 +37,20 @@ jobs:
       - name: Install dependencies
         run: spago install
 
+      # Also emits test-artifacts/corpus.json for the validation step below.
       - name: Run tests
         run: spago test
+
+      - name: Ensure psql is available
+        run: |
+          psql --version || {
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          }
+
+      # Golden tests prove we emit the string we expected. This proves
+      # PostgreSQL accepts it.
+      - name: Validate emitted SQL against PostgreSQL
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/sqld_validate
+        run: node scripts/validate-sql.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .psci_modules/
 .psc-ide-port
 .purs-repl
+test-artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- PostgreSQL validation harness — every query in the corpus is replayed against a real server via `PREPARE`. Because `PREPARE` runs full parse *analysis* rather than a syntax check alone, unknown columns, invalid `GROUP BY`, and operator type mismatches fail alongside malformed SQL. Both formatter outputs are validated: the parameterised form from `format` and the debug form from `formatInline`
-- `Test.Sqld.Corpus` — one canonical corpus of queries, consumed by both the golden tests and the PostgreSQL harness, with each entry tagged by the AST constructors it exercises
-- Coverage ratchet — `Test.Sqld.CorpusSpec` fails if any `Sqld.Core` constructor has no corpus entry, so a new feature cannot ship without SQL that PostgreSQL has accepted
-- `test/fixtures/schema.sql` — fixture tables the corpus references
-- `scripts/validate-sql.mjs` — the validator, supporting `--only <pattern>`, `--sql <query>` for ad-hoc probes, and `--list`
-- `scripts/pg-validate-local.sh` — local runs against a throwaway Docker PostgreSQL container
-- `Makefile` — `make validate`, `validate-fast`, `sql`, `list`, `pg-stop`, and a self-documenting `make help`
-- CI now runs the harness against a `postgres:16` service container on every push and pull request
-
-## [0.1.0] - 2026-05-08
-
-### Added
 - `Sqld.Expr` module — expression constructors, literals, comparison operators, and logical combinators
 - `Sqld.Select` module — SELECT query builders and select-list helpers
 - `cols :: Array String -> Array SelectExpr` — convenience helper for selecting a list of plain column names
@@ -31,17 +19,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JOIN support: `innerJoin`, `leftJoin`, `leftJoinAs`
 - Logical combinators: `and`, `or`, `not`, `isNull`, `isNotNull`
 - Set operators: `in_`, `notIn`
-- Range / pattern operators: `between`, `like`
+- Range / pattern operators: `between`, `like`, `ilike`
 - Comparison infix operators: `.==`, `.!=`, `.<`, `.<=`, `.>`, `.>=`
 - `groupBy` / `having` / `orderBy` / `limit` / `offset`
 - `mergeQueries` for combining query fragments
 - `raw` escape hatch for unsupported SQL fragments
 - Pure `format` function — explicit state threading, no `Effect`
 - `formatInline` — substitutes all values directly into the SQL string (for debugging and logging only)
+- `formatPretty` — like `formatInline`, with each clause on its own line
 - PostgreSQL numbered params (`$1`, `$2`, …); no string interpolation
 - All identifiers double-quoted via `quoteIdent` (PostgreSQL-safe)
-- Pretty Printing Formatting
-- Example Module
+- Example module
+- PostgreSQL validation harness — every query in the corpus is replayed against a real server via `PREPARE`. Because `PREPARE` runs full parse *analysis* rather than a syntax check alone, unknown columns, invalid `GROUP BY`, and operator type mismatches fail alongside malformed SQL. Both formatter outputs are validated: the parameterised form from `format` and the debug form from `formatInline`
+- `Test.Sqld.Corpus` — one canonical corpus of queries, consumed by both the golden tests and the PostgreSQL harness, with each entry tagged by the AST constructors it exercises
+- Coverage ratchet — `Test.Sqld.CorpusSpec` fails if any `Sqld.Core` constructor has no corpus entry, so a new feature cannot ship without SQL that PostgreSQL has accepted
+- `test/fixtures/schema.sql` — fixture tables the corpus references
+- `scripts/validate-sql.mjs` — the validator, supporting `--only <pattern>`, `--sql <query>` for ad-hoc probes, and `--list`
+- `scripts/pg-validate-local.sh` — local runs against a throwaway Docker PostgreSQL container
+- `Makefile` — `make validate`, `validate-fast`, `sql`, `list`, `pg-stop`, and a self-documenting `make help`
+- CI runs the harness against a `postgres:16` service container on every push and pull request
 
 ### Changed
 - `select` is now additive — calling it multiple times appends to the select list rather than replacing it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- PostgreSQL validation harness — every query in the corpus is replayed against a real server via `PREPARE`. Because `PREPARE` runs full parse *analysis* rather than a syntax check alone, unknown columns, invalid `GROUP BY`, and operator type mismatches fail alongside malformed SQL. Both formatter outputs are validated: the parameterised form from `format` and the debug form from `formatInline`
+- `Test.Sqld.Corpus` — one canonical corpus of queries, consumed by both the golden tests and the PostgreSQL harness, with each entry tagged by the AST constructors it exercises
+- Coverage ratchet — `Test.Sqld.CorpusSpec` fails if any `Sqld.Core` constructor has no corpus entry, so a new feature cannot ship without SQL that PostgreSQL has accepted
+- `test/fixtures/schema.sql` — fixture tables the corpus references
+- `scripts/validate-sql.mjs` — the validator, supporting `--only <pattern>`, `--sql <query>` for ad-hoc probes, and `--list`
+- `scripts/pg-validate-local.sh` — local runs against a throwaway Docker PostgreSQL container
+- `Makefile` — `make validate`, `validate-fast`, `sql`, `list`, `pg-stop`, and a self-documenting `make help`
+- CI now runs the harness against a `postgres:16` service container on every push and pull request
+
 ## [0.1.0] - 2026-05-08
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+.DEFAULT_GOAL := help
+.PHONY: help build test validate validate-fast sql list pg-stop clean
+
+# Optional filter: `make validate-fast ONLY=join`
+ONLY ?=
+ARGS := $(if $(ONLY),--only $(ONLY),)
+
+VALIDATOR := node scripts/validate-sql.mjs
+LOCAL_PG  := ./scripts/pg-validate-local.sh
+
+help: ## Show this help
+	@echo "sqld — development targets"
+	@echo
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+	@echo
+	@echo "Variables:"
+	@echo "  ONLY=<pattern>  filter corpus entries by name (validate, validate-fast)"
+	@echo "  SQL=<query>     ad-hoc query for the 'sql' target"
+	@echo
+	@echo "Examples:"
+	@echo "  make validate-fast ONLY=join"
+	@echo "  make sql SQL='SELECT \"u\".* FROM \"users\" AS \"u\"'"
+
+build: ## Compile the library
+	spago build
+
+test: ## Run the golden tests (also emits test-artifacts/corpus.json)
+	spago test
+
+validate: ## Run tests, then validate every query against real PostgreSQL
+	$(LOCAL_PG) $(ARGS)
+
+validate-fast: ## Validate using the existing corpus and a warm container (skips spago test)
+	SQLD_SKIP_TEST=1 $(LOCAL_PG) $(ARGS)
+
+sql: ## Probe one ad-hoc query: make sql SQL='SELECT 1'
+ifndef SQL
+	$(error SQL is not set. Usage: make sql SQL='SELECT 1')
+endif
+	SQLD_SKIP_TEST=1 $(LOCAL_PG) --sql $(call quote,$(SQL))
+
+list: ## List corpus entry names (no database needed)
+	@$(VALIDATOR) --list
+
+pg-stop: ## Remove the local PostgreSQL container
+	docker rm -f sqld-pg-validate 2>/dev/null || true
+
+clean: ## Remove build and test artifacts
+	rm -rf output test-artifacts
+
+# Wraps a value in single quotes, escaping any it already contains, so queries
+# survive the trip through the shell intact.
+quote = '$(subst ','\'',$(1))'

--- a/README.md
+++ b/README.md
@@ -160,6 +160,69 @@ adminFilter = emptyQuery # where_ (col "role" .== str "admin")
 result = format (mergeQueries baseUsers adminFilter)
 ```
 
+## Testing
+
+`make help` lists every development target. The common ones:
+
+```
+make test            # golden tests; also emits test-artifacts/corpus.json
+make validate        # tests + validate every query against real PostgreSQL
+make validate-fast   # validate only, reusing the corpus and a warm container
+```
+
+### PostgreSQL validation
+
+Golden tests prove sqld emits the string we expected. They do not prove
+PostgreSQL accepts it. A second harness closes that gap by replaying every
+corpus query against a real server.
+
+`make validate` starts a throwaway Postgres container, runs `spago test`, then
+feeds each query to the server with `PREPARE`. Because `PREPARE` runs full parse
+*analysis* — not just a syntax check — the harness catches bad syntax, unknown
+columns, invalid `GROUP BY`, and operator type mismatches. Both formatter
+outputs are validated: the parameterised form from `format` and the debug form
+from `formatInline`.
+
+The container is left running between invocations, so `make validate-fast` is
+the quick inner loop. `make pg-stop` tears it down.
+
+To narrow a run, or to probe a query without adding a corpus entry:
+
+```
+make list                                    # corpus entry names
+make validate-fast ONLY=join                 # just the entries matching "join"
+make sql SQL='SELECT "u".* FROM "users" AS "u"'   # ad-hoc query
+```
+
+`make sql` is the fastest way to answer "will PostgreSQL accept this?" while
+working on a formatter change.
+
+Against an existing server, skip the Makefile and drive the validator directly:
+
+```
+DATABASE_URL=postgres://user:pass@host:5432/sqld_validate node scripts/validate-sql.mjs
+```
+
+It accepts the same `--only`, `--sql` and `--list` flags; `--help` lists them.
+
+The schema in `test/fixtures/schema.sql` drops and recreates `public`, so the
+validator refuses to run unless the database name looks disposable. Override
+with `SQLD_ALLOW_ANY_DB=1` only if you are certain.
+
+The same steps run in CI on every push and pull request.
+
+### Coverage
+
+`test/Sqld/Corpus.purs` is the single corpus both harnesses consume. Each entry
+is tagged with the AST constructors it exercises, and `Test.Sqld.CorpusSpec`
+fails if any constructor in `Sqld.Core` has no entry — so a new feature cannot
+ship without SQL that PostgreSQL has actually accepted. Adding a constructor
+makes the tagging functions non-exhaustive, which the compiler reports, and the
+new tag then fails the coverage assertion until a corpus entry exists.
+
+Every table and column the corpus references must exist in
+`test/fixtures/schema.sql`.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/scripts/pg-validate-local.sh
+++ b/scripts/pg-validate-local.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Runs the PostgreSQL validation harness locally against a throwaway container.
+#
+#   ./scripts/pg-validate-local.sh
+#   ./scripts/pg-validate-local.sh --only join
+#
+# Starts (or reuses) a Postgres container, runs `spago test` to emit the corpus,
+# then replays it with scripts/validate-sql.mjs. Extra arguments are forwarded
+# to the validator. Prefer the Makefile targets: `make validate`, `make sql`.
+#
+#   SQLD_PG_PORT=55432   host port to bind
+#   SQLD_PG_IMAGE        Postgres image (default: postgres:16-alpine)
+#   SQLD_PG_STOP=1       remove the container when finished
+#   SQLD_SKIP_TEST=1     skip `spago test`, reuse the existing corpus
+
+set -euo pipefail
+
+IMAGE="${SQLD_PG_IMAGE:-postgres:16-alpine}"
+PORT="${SQLD_PG_PORT:-55432}"
+NAME="sqld-pg-validate"
+DB="sqld_validate"
+
+cd "$(dirname "$0")/.."
+
+if ! docker info >/dev/null 2>&1; then
+  echo "pg-validate-local: docker is not running" >&2
+  exit 1
+fi
+
+if [ -z "$(docker ps -q -f "name=^${NAME}$")" ]; then
+  # Clear out a stopped container left over from a previous run.
+  if [ -n "$(docker ps -aq -f "name=^${NAME}$")" ]; then
+    docker rm -f "$NAME" >/dev/null
+  fi
+
+  echo "pg-validate-local: starting ${IMAGE} on port ${PORT}"
+  docker run -d --rm \
+    --name "$NAME" \
+    -e POSTGRES_USER=postgres \
+    -e POSTGRES_PASSWORD=postgres \
+    -e POSTGRES_DB="$DB" \
+    -p "${PORT}:5432" \
+    "$IMAGE" >/dev/null
+
+  printf "pg-validate-local: waiting for postgres"
+  for _ in $(seq 1 60); do
+    if docker exec "$NAME" pg_isready -U postgres -d "$DB" >/dev/null 2>&1; then
+      echo " ready"
+      break
+    fi
+    printf "."
+    sleep 1
+  done
+
+  if ! docker exec "$NAME" pg_isready -U postgres -d "$DB" >/dev/null 2>&1; then
+    echo
+    echo "pg-validate-local: postgres did not become ready" >&2
+    docker logs "$NAME" >&2
+    exit 1
+  fi
+else
+  echo "pg-validate-local: reusing running container ${NAME}"
+fi
+
+cleanup() {
+  if [ "${SQLD_PG_STOP:-0}" = "1" ]; then
+    echo "pg-validate-local: removing container ${NAME}"
+    docker rm -f "$NAME" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+if [ "${SQLD_SKIP_TEST:-0}" != "1" ]; then
+  echo "pg-validate-local: emitting corpus via spago test"
+  spago test
+fi
+
+export DATABASE_URL="postgres://postgres:postgres@localhost:${PORT}/${DB}"
+
+# Any extra arguments are forwarded to the validator, so --only / --sql work
+# through this script too. `|| status=$?` keeps `set -e` from aborting before
+# the teardown hint below.
+status=0
+node scripts/validate-sql.mjs "$@" || status=$?
+
+if [ "${SQLD_PG_STOP:-0}" != "1" ]; then
+  echo
+  echo "pg-validate-local: container ${NAME} left running (stop it with: docker rm -f ${NAME})"
+fi
+
+exit $status

--- a/scripts/validate-sql.mjs
+++ b/scripts/validate-sql.mjs
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+// Replays the emitted query corpus against a real PostgreSQL server.
+//
+// Golden tests prove sqld emits the string we expected. They do not prove
+// PostgreSQL accepts it. This script closes that gap: every corpus entry is fed
+// to the server via PREPARE, which runs the full parser AND parse analysis, so
+// bad syntax, unknown columns, invalid GROUP BY and operator type mismatches
+// all fail here.
+//
+// Both formatter outputs are checked:
+//   * `sql`       — the parameterised form from `Sqld.Format.format`
+//   * `inlineSql` — the debug form from `Sqld.Format.formatInline`
+//
+// Usage:
+//   spago test                                    # emits test-artifacts/corpus.json
+//   node scripts/validate-sql.mjs                 # validate the whole corpus
+//   node scripts/validate-sql.mjs --only join     # just the entries matching "join"
+//   node scripts/validate-sql.mjs --sql 'SELECT 1'  # probe an ad-hoc query
+//   node scripts/validate-sql.mjs --list          # list corpus entry names
+//
+// Configuration:
+//   DATABASE_URL        connection URI (default: local throwaway database)
+//   SQLD_ALLOW_ANY_DB   set to 1 to bypass the disposable-database guard
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+
+const CORPUS_PATH = "test-artifacts/corpus.json";
+const SCHEMA_PATH = "test/fixtures/schema.sql";
+const DEFAULT_URL = "postgres://postgres:postgres@localhost:5432/sqld_validate";
+
+// PostgreSQL cannot always infer a placeholder's type from context (`SELECT $1
+// IS NULL` has nothing to unify against). That is a limitation of the
+// parameterised form, not a malformed query — the inline form still gets full
+// validation — so it is reported as a warning rather than a failure.
+const INDETERMINATE_DATATYPE = "42P18";
+
+const conn = process.env.DATABASE_URL ?? DEFAULT_URL;
+
+function die(message) {
+  console.error(`\nvalidate-sql: ${message}\n`);
+  process.exit(1);
+}
+
+// --- arguments -------------------------------------------------------------
+
+const USAGE = `Usage: node scripts/validate-sql.mjs [options]
+
+  --only <pattern>   validate only corpus entries whose name contains <pattern>
+  --sql <query>      validate a single ad-hoc query instead of the corpus
+  --list             list corpus entry names and exit
+  -h, --help         show this message
+
+Environment:
+  DATABASE_URL       connection URI
+                     (default: ${DEFAULT_URL})
+  SQLD_ALLOW_ANY_DB  set to 1 to bypass the disposable-database guard`;
+
+function parseArgs(argv) {
+  const options = { only: null, sql: null, list: false };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const takeValue = (name) => {
+      const value = argv[++i];
+      if (value === undefined) die(`${name} requires a value.\n\n${USAGE}`);
+      return value;
+    };
+
+    switch (arg) {
+      case "--only":
+        options.only = takeValue("--only");
+        break;
+      case "--sql":
+        options.sql = takeValue("--sql");
+        break;
+      case "--list":
+        options.list = true;
+        break;
+      case "-h":
+      case "--help":
+        console.log(USAGE);
+        process.exit(0);
+      // eslint-disable-next-line no-fallthrough
+      default:
+        die(`unknown option "${arg}".\n\n${USAGE}`);
+    }
+  }
+
+  if (options.sql !== null && options.only !== null) {
+    die("--sql and --only are mutually exclusive.");
+  }
+
+  return options;
+}
+
+const options = parseArgs(process.argv.slice(2));
+
+// --- corpus ----------------------------------------------------------------
+
+function loadCorpus() {
+  if (!existsSync(CORPUS_PATH)) {
+    die(`${CORPUS_PATH} not found. Run \`spago test\` first to emit the corpus.`);
+  }
+  return JSON.parse(readFileSync(CORPUS_PATH, "utf8"));
+}
+
+// Listing needs neither a database nor the disposable-database guard.
+if (options.list) {
+  for (const entry of loadCorpus()) console.log(entry.name);
+  process.exit(0);
+}
+
+let entries;
+
+if (options.sql !== null) {
+  // Ad-hoc probes carry no parameter list, so the placeholder cross-check and
+  // the inline form do not apply.
+  entries = [{ name: "ad-hoc", sql: options.sql, inlineSql: null, params: null }];
+} else {
+  entries = loadCorpus();
+
+  if (options.only !== null) {
+    const needle = options.only.toLowerCase();
+    entries = entries.filter((entry) => entry.name.toLowerCase().includes(needle));
+
+    if (!entries.length) {
+      die(
+        `no corpus entry matches "${options.only}".\n` +
+          `Run \`node scripts/validate-sql.mjs --list\` to see the available names.`,
+      );
+    }
+  }
+}
+
+// --- guards ----------------------------------------------------------------
+
+function assertDisposableDatabase(url) {
+  if (process.env.SQLD_ALLOW_ANY_DB === "1") return;
+
+  let name;
+  try {
+    name = new URL(url).pathname.replace(/^\//, "");
+  } catch {
+    die(
+      `could not parse DATABASE_URL as a URI, so the disposable-database guard ` +
+        `cannot run.\nApplying ${SCHEMA_PATH} DROPs and recreates the public schema. ` +
+        `Set SQLD_ALLOW_ANY_DB=1 only if the target is throwaway.`,
+    );
+  }
+
+  if (!/(sqld|validate|test|ci)/i.test(name)) {
+    die(
+      `refusing to run against database "${name}".\n` +
+        `Applying ${SCHEMA_PATH} DROPs and recreates the public schema, destroying ` +
+        `everything in it.\nPoint DATABASE_URL at a throwaway database (a name ` +
+        `containing "sqld", "validate", "test" or "ci"), or set SQLD_ALLOW_ANY_DB=1 ` +
+        `if you are certain.`,
+    );
+  }
+}
+
+// --- psql ------------------------------------------------------------------
+
+// Runs SQL in a fresh psql session. Returns null on success, or the server's
+// error text. Verbose output puts the SQLSTATE in the ERROR line, which is how
+// we classify failures.
+function runSql(sql) {
+  try {
+    execFileSync("psql", [conn, "-X", "-q", "-v", "ON_ERROR_STOP=1"], {
+      input: `\\set VERBOSITY verbose\n${sql}\n`,
+      stdio: ["pipe", "pipe", "pipe"],
+      encoding: "utf8",
+    });
+    return null;
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      die("psql not found on PATH. Install the PostgreSQL client tools.");
+    }
+    return (err.stderr ?? String(err)).trim();
+  }
+}
+
+function sqlState(errorText) {
+  return errorText.match(/ERROR:\s+([0-9A-Z]{5}):/)?.[1] ?? null;
+}
+
+// Verbose errors carry a LOCATION line pointing into the Postgres C source,
+// which is noise for this audience.
+function tidy(errorText) {
+  return errorText
+    .split("\n")
+    .filter((line) => !/^LOCATION:/.test(line))
+    .map((line) => line.replace(/^psql:<stdin>:\d+:\s*/, ""))
+    .join("\n");
+}
+
+// --- checks ----------------------------------------------------------------
+
+function checkPlaceholders(entry) {
+  const highest = [...entry.sql.matchAll(/\$(\d+)/g)]
+    .map((m) => Number(m[1]))
+    .reduce((a, b) => Math.max(a, b), 0);
+
+  if (highest !== entry.params.length) {
+    return (
+      `placeholder/parameter mismatch: highest placeholder is $${highest} but ` +
+      `${entry.params.length} parameter(s) were bound`
+    );
+  }
+  return null;
+}
+
+function checkPrepares(sql) {
+  const error = runSql(`PREPARE sqld_validate_stmt AS ${sql};`);
+  if (error === null) return { status: "pass" };
+  if (sqlState(error) === INDETERMINATE_DATATYPE) {
+    return { status: "warn", detail: tidy(error) };
+  }
+  return { status: "fail", detail: tidy(error) };
+}
+
+// --- main ------------------------------------------------------------------
+
+assertDisposableDatabase(conn);
+
+console.log(`validate-sql: ${entries.length} ${entries.length === 1 ? "query" : "queries"}`);
+console.log(`validate-sql: applying ${SCHEMA_PATH}\n`);
+
+try {
+  execFileSync("psql", [conn, "-X", "-q", "-v", "ON_ERROR_STOP=1", "-f", SCHEMA_PATH], {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+} catch (err) {
+  if (err.code === "ENOENT") die("psql not found on PATH.");
+  die(`could not apply ${SCHEMA_PATH}:\n\n${(err.stderr ?? String(err)).trim()}`);
+}
+
+const failures = [];
+const warnings = [];
+
+for (const entry of entries) {
+  const problems = [];
+
+  if (entry.params !== null) {
+    const mismatch = checkPlaceholders(entry);
+    if (mismatch) problems.push({ form: "params", status: "fail", detail: mismatch });
+  }
+
+  const forms = [["format", entry.sql]];
+  if (entry.inlineSql !== null) forms.push(["formatInline", entry.inlineSql]);
+
+  for (const [form, sql] of forms) {
+    const result = checkPrepares(sql);
+    if (result.status !== "pass") problems.push({ form, ...result, sql });
+  }
+
+  const failed = problems.filter((p) => p.status === "fail");
+  const warned = problems.filter((p) => p.status === "warn");
+
+  if (failed.length) {
+    failures.push({ entry, problems: failed });
+    console.log(`  FAIL  ${entry.name}`);
+  } else if (warned.length) {
+    warnings.push({ entry, problems: warned });
+    console.log(`  WARN  ${entry.name}`);
+  } else {
+    console.log(`  ok    ${entry.name}`);
+  }
+}
+
+function report(label, items) {
+  if (!items.length) return;
+  console.log(`\n${label}\n${"=".repeat(label.length)}`);
+  for (const { entry, problems } of items) {
+    for (const problem of problems) {
+      console.log(`\n${entry.name} [${problem.form}]`);
+      if (problem.sql) console.log(`  ${problem.sql}`);
+      console.log(
+        problem.detail
+          .split("\n")
+          .map((line) => `  ${line}`)
+          .join("\n"),
+      );
+    }
+  }
+}
+
+report("Warnings", warnings);
+report("Failures", failures);
+
+console.log(
+  `\nvalidate-sql: ${entries.length - failures.length - warnings.length} passed, ` +
+    `${warnings.length} warned, ${failures.length} failed`,
+);
+
+process.exit(failures.length ? 1 : 0);

--- a/spago.lock
+++ b/spago.lock
@@ -20,6 +20,8 @@
             "aff",
             "console",
             "effect",
+            "node-buffer",
+            "node-fs",
             "spec"
           ]
         }
@@ -700,6 +702,12 @@
         "prelude"
       ]
     },
+    "arraybuffer-types": {
+      "type": "registry",
+      "version": "3.0.2",
+      "integrity": "sha256-p05cJnSkyeoB7VHzMyc2Eb1RwUaB7Nl0sQSqEGNEUD8=",
+      "dependencies": []
+    },
     "arrays": {
       "type": "registry",
       "version": "7.3.0",
@@ -909,6 +917,22 @@
         "tuples"
       ]
     },
+    "foreign": {
+      "type": "registry",
+      "version": "7.0.0",
+      "integrity": "sha256-jiDRMVQfovGsbbA/FzbzYf6iWk9i2b5gNrIjz+gFfsI=",
+      "dependencies": [
+        "either",
+        "functions",
+        "integers",
+        "lists",
+        "maybe",
+        "prelude",
+        "strings",
+        "transformers",
+        "unsafe-coerce"
+      ]
+    },
     "fork": {
       "type": "registry",
       "version": "6.0.0",
@@ -1015,6 +1039,21 @@
         "prelude"
       ]
     },
+    "js-date": {
+      "type": "registry",
+      "version": "8.0.0",
+      "integrity": "sha256-DNQrp4xYc8o80jtxo0aOkUeXGi6h0Xidkk2ZQ8Y4l5Y=",
+      "dependencies": [
+        "datetime",
+        "effect",
+        "enums",
+        "foreign",
+        "functions",
+        "integers",
+        "maybe",
+        "prelude"
+      ]
+    },
     "lazy": {
       "type": "registry",
       "version": "6.0.0",
@@ -1082,6 +1121,89 @@
         "safe-coerce"
       ]
     },
+    "node-buffer": {
+      "type": "registry",
+      "version": "9.0.0",
+      "integrity": "sha256-RdQjilmEHqsT4fwpCr8Mavw8KTafYrS3ZM6zeAAVAl8=",
+      "dependencies": [
+        "arraybuffer-types",
+        "effect",
+        "functions",
+        "maybe",
+        "nullable",
+        "partial",
+        "prelude",
+        "st",
+        "unsafe-coerce"
+      ]
+    },
+    "node-event-emitter": {
+      "type": "registry",
+      "version": "3.0.0",
+      "integrity": "sha256-wodx71NxJBPXOaawFn01V1ByYB2vT+I3RuV2giOVKMg=",
+      "dependencies": [
+        "effect",
+        "either",
+        "functions",
+        "maybe",
+        "nullable",
+        "prelude",
+        "unsafe-coerce"
+      ]
+    },
+    "node-fs": {
+      "type": "registry",
+      "version": "9.2.0",
+      "integrity": "sha256-fxioTSm9y47WuYs9F/7nxCh/RVDCl3Kr3Hg779J4SJA=",
+      "dependencies": [
+        "aff",
+        "datetime",
+        "effect",
+        "either",
+        "enums",
+        "exceptions",
+        "functions",
+        "integers",
+        "js-date",
+        "maybe",
+        "node-buffer",
+        "node-path",
+        "node-streams",
+        "nullable",
+        "partial",
+        "prelude",
+        "strings"
+      ]
+    },
+    "node-path": {
+      "type": "registry",
+      "version": "5.0.1",
+      "integrity": "sha256-j7n/SmpVz0FOMJl4XZop3ofJ+MeIPkMNqUEUKHEL6Us=",
+      "dependencies": [
+        "effect"
+      ]
+    },
+    "node-streams": {
+      "type": "registry",
+      "version": "9.0.1",
+      "integrity": "sha256-yuVGm/R/tBr4Nphi+a1a984Z0fkmN9Q5wWtSmbmJTpA=",
+      "dependencies": [
+        "aff",
+        "arrays",
+        "effect",
+        "either",
+        "exceptions",
+        "maybe",
+        "node-buffer",
+        "node-event-emitter",
+        "nullable",
+        "prelude",
+        "refs",
+        "st",
+        "tailrec",
+        "unsafe-coerce"
+      ]
+    },
     "nonempty": {
       "type": "registry",
       "version": "7.0.0",
@@ -1102,6 +1224,16 @@
       "dependencies": [
         "datetime",
         "effect",
+        "prelude"
+      ]
+    },
+    "nullable": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-CDAZk+L9Sc0GCFTkE8n+qdp4Ys8avvnkU+m2hVALt7M=",
+      "dependencies": [
+        "functions",
+        "maybe",
         "prelude"
       ]
     },

--- a/spago.yaml
+++ b/spago.yaml
@@ -23,6 +23,8 @@ package:
       - aff
       - console
       - effect
+      - node-buffer
+      - node-fs
       - spec
 
 workspace:

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,12 +5,19 @@ import Effect (Effect)
 import Effect.Aff (launchAff_)
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner (runSpec)
+import Test.Sqld.CorpusEmit (emitCorpusJson)
+import Test.Sqld.CorpusSpec (corpusSpec)
 import Test.Sqld.ExprSpec (exprSpec)
 import Test.Sqld.FormatSpec (formatSpec)
 import Test.Sqld.SelectSpec (selectSpec)
 
 main :: Effect Unit
-main = launchAff_ $ runSpec [consoleReporter] do
-  exprSpec
-  selectSpec
-  formatSpec
+main = do
+  -- Emitted before the suite runs so `scripts/validate-sql.mjs` has a corpus to
+  -- replay even when a golden test fails.
+  emitCorpusJson
+  launchAff_ $ runSpec [consoleReporter] do
+    exprSpec
+    selectSpec
+    formatSpec
+    corpusSpec

--- a/test/Sqld/Corpus.purs
+++ b/test/Sqld/Corpus.purs
@@ -1,0 +1,442 @@
+-- | The validation corpus: one canonical set of queries that every backend
+-- | check runs against.
+-- |
+-- | Two things consume this module:
+-- |
+-- |   * `Test.Sqld.CorpusSpec` — asserts the corpus exercises every AST
+-- |     constructor, so coverage cannot silently regress.
+-- |   * `Test.Sqld.CorpusEmit` — writes the formatted SQL to
+-- |     `test-artifacts/corpus.json`, which `scripts/validate-sql.mjs` feeds
+-- |     through a real PostgreSQL server.
+-- |
+-- | Every table and column referenced here MUST exist in
+-- | `test/fixtures/schema.sql`. Postgres runs full parse analysis on these
+-- | queries, so a typo in a column name is a test failure — that is the point.
+module Test.Sqld.Corpus
+  ( CorpusEntry
+  , corpus
+  , coveredTags
+  , requiredTags
+  , missingTags
+  ) where
+
+import Prelude hiding (between, not)
+
+import Data.Array ((:))
+import Data.Array (concatMap, difference, nub, null, sort) as Array
+import Data.Maybe (Maybe(..), isJust)
+import Sqld.Core (Expr(..), JoinType(..), Literal(..), OrderDir(..), OrderExpr, Query, Relation, SelectExpr(..), emptyQuery)
+import Sqld.Expr (and, between, bool, col, ilike, in_, int, isNotNull, isNull, like, not, notIn, null, num, or, raw, str, tcol, (.!=), (.<), (.<=), (.==), (.>), (.>=))
+import Sqld.Select (as, asc, colAs, cols, desc, expr, from, fromAs, groupBy, having, innerJoin, leftJoinAs, limit, offset, orderBy, rel, relAs, select, star, tcolAs, where_)
+
+type CorpusEntry = { name :: String, query :: Query }
+
+-- ---------------------------------------------------------------------------
+-- Builders the public API does not (yet) expose
+-- ---------------------------------------------------------------------------
+
+-- | `Sqld.Select` has no `rightJoin` / `fullJoin`, so the corpus reaches for the
+-- | `Sqld.Core` constructors directly to keep those code paths covered.
+joinWith :: JoinType -> Relation -> Expr -> Query -> Query
+joinWith type_ relation on q =
+  q { joins = q.joins <> [ { type_, relation, on } ] }
+
+-- | `Sqld.Select` has no `starFrom`, so build `SelectStarFrom` by hand.
+starFrom :: String -> SelectExpr
+starFrom = SelectStarFrom
+
+-- ---------------------------------------------------------------------------
+-- The corpus
+-- ---------------------------------------------------------------------------
+
+corpus :: Array CorpusEntry
+corpus =
+  [ { name: "select-star"
+    , query: emptyQuery # select [ star ] # from "users"
+    }
+
+  , { name: "select-columns"
+    , query: emptyQuery # select (cols [ "id", "name", "email" ]) # from "users"
+    }
+
+  , { name: "select-alias"
+    , query: emptyQuery # select [ as (col "created_at") "ts" ] # from "users"
+    }
+
+  , { name: "select-col-alias-shorthand"
+    , query: emptyQuery # select [ colAs "created_at" "ts" ] # from "users"
+    }
+
+  , { name: "select-qualified-columns"
+    , query: emptyQuery
+        # select [ expr (tcol "u" "id"), expr (tcol "u" "name") ]
+        # fromAs "users" "u"
+    }
+
+  , { name: "select-qualified-alias"
+    , query: emptyQuery
+        # select [ tcolAs "u" "created_at" "ts" ]
+        # fromAs "users" "u"
+    }
+
+  , { name: "select-star-from-alias"
+    , query: emptyQuery # select [ starFrom "u" ] # fromAs "users" "u"
+    }
+
+  , { name: "select-raw-expression"
+    , query: emptyQuery # select [ expr (raw "1 + 1") ]
+    }
+
+  , { name: "select-aggregate-alias"
+    , query: emptyQuery
+        # select [ expr (col "department"), as (raw "COUNT(*)") "n" ]
+        # from "users"
+        # groupBy [ col "department" ]
+    }
+
+  -- Literals -----------------------------------------------------------------
+
+  , { name: "literal-int"
+    , query: emptyQuery # select [ star ] # from "users" # where_ (col "id" .== int 42)
+    }
+
+  , { name: "literal-string-with-quote"
+    , query: emptyQuery # select [ star ] # from "users" # where_ (col "name" .!= str "O'Brien")
+    }
+
+  , { name: "literal-number"
+    , query: emptyQuery # select [ star ] # from "users" # where_ (col "score" .>= num 4.5)
+    }
+
+  , { name: "literal-boolean"
+    , query: emptyQuery # select [ star ] # from "users" # where_ (col "active" .== bool true)
+    }
+
+  , { name: "literal-null"
+    , query: emptyQuery # select [ star ] # from "users" # where_ (col "email" .== null)
+    }
+
+  -- Comparison operators -----------------------------------------------------
+
+  , { name: "comparison-operators"
+    , query: emptyQuery
+        # select [ star ]
+        # from "users"
+        # where_
+            ( and
+                [ col "age" .> int 18
+                , col "age" .>= int 21
+                , col "age" .< int 65
+                , col "age" .<= int 64
+                ]
+            )
+    }
+
+  -- Boolean combinators ------------------------------------------------------
+
+  , { name: "boolean-or"
+    , query: emptyQuery
+        # select [ star ]
+        # from "users"
+        # where_ (or [ col "active" .== bool true, isNull (col "email") ])
+    }
+
+  , { name: "boolean-not"
+    , query: emptyQuery
+        # select [ star ]
+        # from "users"
+        # where_ (not (col "active" .== bool true))
+    }
+
+  , { name: "boolean-and-empty"
+    , query: emptyQuery # select [ star ] # from "users" # where_ (and [])
+    }
+
+  , { name: "boolean-or-empty"
+    , query: emptyQuery # select [ star ] # from "users" # where_ (or [])
+    }
+
+  -- Null tests ---------------------------------------------------------------
+
+  , { name: "is-null-and-is-not-null"
+    , query: emptyQuery
+        # select [ star ]
+        # from "users"
+        # where_ (and [ isNull (col "email"), isNotNull (col "name") ])
+    }
+
+  -- Set membership -----------------------------------------------------------
+
+  , { name: "in-list"
+    , query: emptyQuery
+        # select [ star ]
+        # from "users"
+        # where_ (in_ (col "department") [ str "engineering", str "sales" ])
+    }
+
+  , { name: "not-in-list"
+    , query: emptyQuery
+        # select [ star ]
+        # from "users"
+        # where_ (notIn (col "id") [ int 1, int 2, int 3 ])
+    }
+
+  -- Pattern matching ---------------------------------------------------------
+
+  , { name: "like"
+    , query: emptyQuery # select [ star ] # from "users" # where_ (like (col "name") "A%")
+    }
+
+  , { name: "ilike"
+    , query: emptyQuery # select [ star ] # from "users" # where_ (ilike (col "email") "%@example.com")
+    }
+
+  -- Ranges -------------------------------------------------------------------
+
+  , { name: "between"
+    , query: emptyQuery
+        # select [ star ]
+        # from "users"
+        # where_ (between (col "age") (int 18) (int 65))
+    }
+
+  -- Raw escape hatch ---------------------------------------------------------
+
+  , { name: "where-raw"
+    , query: emptyQuery # select [ star ] # from "users" # where_ (raw "age % 2 = 0")
+    }
+
+  -- Joins --------------------------------------------------------------------
+
+  , { name: "inner-join"
+    , query: emptyQuery
+        # select [ star ]
+        # from "orders"
+        # innerJoin "users" (tcol "orders" "user_id" .== tcol "users" "id")
+    }
+
+  , { name: "left-join-with-aliases"
+    , query: emptyQuery
+        # select [ expr (tcol "u" "id"), expr (tcol "p" "bio") ]
+        # fromAs "users" "u"
+        # leftJoinAs "profiles" "p" (tcol "u" "id" .== tcol "p" "user_id")
+        # where_ (tcol "u" "active" .== bool true)
+        # orderBy [ desc (tcol "u" "created_at") ]
+        # limit 20
+    }
+
+  , { name: "right-join"
+    , query: emptyQuery
+        # select [ star ]
+        # from "users"
+        # joinWith RightJoin (rel "profiles") (tcol "users" "id" .== tcol "profiles" "user_id")
+    }
+
+  , { name: "full-join"
+    , query: emptyQuery
+        # select [ star ]
+        # fromAs "users" "u"
+        # joinWith FullJoin (relAs "profiles" "p") (tcol "u" "id" .== tcol "p" "user_id")
+    }
+
+  -- Grouping -----------------------------------------------------------------
+
+  , { name: "group-by-having"
+    , query: emptyQuery
+        # select [ expr (col "department"), as (raw "COUNT(*)") "headcount" ]
+        # from "users"
+        # groupBy [ col "department" ]
+        # having (raw "COUNT(*)" .> int 5)
+        # orderBy [ desc (col "headcount") ]
+    }
+
+  -- Ordering / pagination ----------------------------------------------------
+
+  , { name: "order-by-asc"
+    , query: emptyQuery # select [ star ] # from "users" # orderBy [ asc (col "name") ]
+    }
+
+  , { name: "order-by-multiple"
+    , query: emptyQuery
+        # select [ star ]
+        # from "users"
+        # orderBy [ asc (col "department"), desc (col "created_at") ]
+    }
+
+  , { name: "limit-offset"
+    , query: emptyQuery
+        # select [ star ]
+        # from "articles"
+        # orderBy [ desc (col "published_at") ]
+        # limit 10
+        # offset 20
+    }
+
+  -- Everything at once -------------------------------------------------------
+
+  , { name: "kitchen-sink"
+    , query: emptyQuery
+        # select [ tcolAs "u" "id" "user_id", as (raw "COUNT(o.id)") "order_count" ]
+        # fromAs "users" "u"
+        # leftJoinAs "orders" "o" (tcol "u" "id" .== tcol "o" "user_id")
+        # where_
+            ( and
+                [ tcol "u" "active" .== bool true
+                , isNotNull (tcol "u" "email")
+                , in_ (tcol "u" "department") [ str "engineering", str "sales" ]
+                ]
+            )
+        # groupBy [ tcol "u" "id" ]
+        # having (raw "COUNT(o.id)" .> int 0)
+        # orderBy [ desc (raw "COUNT(o.id)"), asc (tcol "u" "id") ]
+        # limit 25
+        # offset 50
+    }
+  ]
+
+-- ---------------------------------------------------------------------------
+-- Coverage tagging
+-- ---------------------------------------------------------------------------
+--
+-- `exprTags`, `selectTags`, `literalTag`, `joinTypeTag` and `orderDirTag` are
+-- exhaustive pattern matches. Adding a constructor to `Sqld.Core` makes them
+-- incomplete, which the compiler reports; adding the case then forces a new
+-- tag, and `missingTags` fails the suite until the corpus exercises it.
+
+exprTags :: Expr -> Array String
+exprTags e = case e of
+  Col { table } -> [ if isJust table then "Expr.Col.qualified" else "Expr.Col" ]
+  Lit l -> [ "Expr.Lit", "Literal." <> literalTag l ]
+  Eq a b -> node "Expr.Eq" [ a, b ]
+  Neq a b -> node "Expr.Neq" [ a, b ]
+  Lt a b -> node "Expr.Lt" [ a, b ]
+  Lte a b -> node "Expr.Lte" [ a, b ]
+  Gt a b -> node "Expr.Gt" [ a, b ]
+  Gte a b -> node "Expr.Gte" [ a, b ]
+  And xs -> node (if Array.null xs then "Expr.And.empty" else "Expr.And") xs
+  Or xs -> node (if Array.null xs then "Expr.Or.empty" else "Expr.Or") xs
+  Not x -> node "Expr.Not" [ x ]
+  IsNull x -> node "Expr.IsNull" [ x ]
+  IsNotNull x -> node "Expr.IsNotNull" [ x ]
+  In x xs -> node "Expr.In" (x : xs)
+  NotIn x xs -> node "Expr.NotIn" (x : xs)
+  Like x p -> node "Expr.Like" [ x, p ]
+  ILike x p -> node "Expr.ILike" [ x, p ]
+  Between x lo hi -> node "Expr.Between" [ x, lo, hi ]
+  Raw _ -> [ "Expr.Raw" ]
+  where
+  node tag kids = tag : Array.concatMap exprTags kids
+
+literalTag :: Literal -> String
+literalTag = case _ of
+  LitInt _ -> "LitInt"
+  LitNumber _ -> "LitNumber"
+  LitString _ -> "LitString"
+  LitBoolean _ -> "LitBoolean"
+  LitNull -> "LitNull"
+
+selectTags :: SelectExpr -> Array String
+selectTags = case _ of
+  SelectStar -> [ "SelectExpr.SelectStar" ]
+  SelectStarFrom _ -> [ "SelectExpr.SelectStarFrom" ]
+  SelectExpr e -> "SelectExpr.SelectExpr" : exprTags e
+  SelectAs e _ -> "SelectExpr.SelectAs" : exprTags e
+
+joinTypeTag :: JoinType -> String
+joinTypeTag = case _ of
+  InnerJoin -> "JoinType.InnerJoin"
+  LeftJoin -> "JoinType.LeftJoin"
+  RightJoin -> "JoinType.RightJoin"
+  FullJoin -> "JoinType.FullJoin"
+
+orderDirTag :: OrderDir -> String
+orderDirTag = case _ of
+  Asc -> "OrderDir.Asc"
+  Desc -> "OrderDir.Desc"
+
+orderTags :: OrderExpr -> Array String
+orderTags o = orderDirTag o.dir : exprTags o.expr
+
+relationTags :: String -> Relation -> Array String
+relationTags prefix r = case r.alias of
+  Nothing -> [ prefix ]
+  Just _ -> [ prefix, prefix <> ".alias" ]
+
+queryTags :: Query -> Array String
+queryTags q =
+  Array.concatMap selectTags q.select
+    <> foldClause "Query.from" (map (relationTags "Query.from") q.from)
+    <> Array.concatMap (\j -> joinTypeTag j.type_ : relationTags "Query.join" j.relation <> exprTags j.on) q.joins
+    <> foldClause "Query.where" (map exprTags q.where_)
+    <> clause "Query.groupBy" (Array.concatMap exprTags q.groupBy) (Array.null q.groupBy)
+    <> foldClause "Query.having" (map exprTags q.having)
+    <> clause "Query.orderBy" (Array.concatMap orderTags q.orderBy) (Array.null q.orderBy)
+    <> foldClause "Query.limit" (map (const []) q.limit)
+    <> foldClause "Query.offset" (map (const []) q.offset)
+  where
+  foldClause tag = case _ of
+    Nothing -> []
+    Just inner -> tag : inner
+
+  clause tag inner isEmpty = if isEmpty then [] else tag : inner
+
+-- | Every feature tag the corpus actually exercises.
+coveredTags :: Array String
+coveredTags = Array.sort (Array.nub (Array.concatMap (\e -> queryTags e.query) corpus))
+
+-- | Every feature tag the corpus is required to exercise. Keep in sync with
+-- | `Sqld.Core` — a new constructor belongs here and in a corpus entry.
+requiredTags :: Array String
+requiredTags = Array.sort
+  [ "Expr.Col"
+  , "Expr.Col.qualified"
+  , "Expr.Lit"
+  , "Expr.Eq"
+  , "Expr.Neq"
+  , "Expr.Lt"
+  , "Expr.Lte"
+  , "Expr.Gt"
+  , "Expr.Gte"
+  , "Expr.And"
+  , "Expr.And.empty"
+  , "Expr.Or"
+  , "Expr.Or.empty"
+  , "Expr.Not"
+  , "Expr.IsNull"
+  , "Expr.IsNotNull"
+  , "Expr.In"
+  , "Expr.NotIn"
+  , "Expr.Like"
+  , "Expr.ILike"
+  , "Expr.Between"
+  , "Expr.Raw"
+  , "Literal.LitInt"
+  , "Literal.LitNumber"
+  , "Literal.LitString"
+  , "Literal.LitBoolean"
+  , "Literal.LitNull"
+  , "SelectExpr.SelectExpr"
+  , "SelectExpr.SelectAs"
+  , "SelectExpr.SelectStar"
+  , "SelectExpr.SelectStarFrom"
+  , "JoinType.InnerJoin"
+  , "JoinType.LeftJoin"
+  , "JoinType.RightJoin"
+  , "JoinType.FullJoin"
+  , "OrderDir.Asc"
+  , "OrderDir.Desc"
+  , "Query.from"
+  , "Query.from.alias"
+  , "Query.join"
+  , "Query.join.alias"
+  , "Query.where"
+  , "Query.groupBy"
+  , "Query.having"
+  , "Query.orderBy"
+  , "Query.limit"
+  , "Query.offset"
+  ]
+
+-- | Required tags with no corpus entry. Must be empty.
+missingTags :: Array String
+missingTags = Array.difference requiredTags coveredTags

--- a/test/Sqld/CorpusEmit.purs
+++ b/test/Sqld/CorpusEmit.purs
@@ -1,0 +1,76 @@
+-- | Writes the validation corpus to disk as JSON so `scripts/validate-sql.mjs`
+-- | can replay it against a real PostgreSQL server.
+-- |
+-- | JSON is hand-rolled rather than pulled in via argonaut: the shape is three
+-- | fields wide and this keeps the test suite's dependency footprint small.
+module Test.Sqld.CorpusEmit
+  ( corpusPath
+  , corpusJson
+  , emitCorpusJson
+  ) where
+
+import Prelude
+
+import Data.Foldable (intercalate)
+import Data.String as String
+import Effect (Effect)
+import Node.Encoding (Encoding(..))
+import Node.FS.Perms (permsAll)
+import Node.FS.Sync (mkdir', writeTextFile)
+import Sqld.Core (Literal(..))
+import Sqld.Format (format, formatInline)
+import Test.Sqld.Corpus (CorpusEntry, corpus)
+
+corpusDir :: String
+corpusDir = "test-artifacts"
+
+corpusPath :: String
+corpusPath = corpusDir <> "/corpus.json"
+
+emitCorpusJson :: Effect Unit
+emitCorpusJson = do
+  mkdir' corpusDir { recursive: true, mode: permsAll }
+  writeTextFile UTF8 corpusPath corpusJson
+
+corpusJson :: String
+corpusJson = "[\n" <> intercalate ",\n" (map entryJson corpus) <> "\n]\n"
+
+entryJson :: CorpusEntry -> String
+entryJson entry =
+  let
+    formatted = format entry.query
+  in
+    "  { \"name\": " <> jsonString entry.name
+      <> ", \"sql\": "
+      <> jsonString formatted.sql
+      <> ", \"params\": ["
+      <> intercalate ", " (map literalJson formatted.params)
+      <> "]"
+      <> ", \"inlineSql\": "
+      <> jsonString (formatInline entry.query)
+      <> " }"
+
+literalJson :: Literal -> String
+literalJson = case _ of
+  LitInt n -> show n
+  LitNumber n -> show n
+  LitString s -> jsonString s
+  LitBoolean b -> if b then "true" else "false"
+  LitNull -> "null"
+
+-- | Escapes the characters that can appear in generated SQL. Formatted queries
+-- | are single-line ASCII-plus-user-literals, so the JSON control-character
+-- | escapes that matter are the ones handled here.
+jsonString :: String -> String
+jsonString s = "\"" <> escaped <> "\""
+  where
+  escaped =
+    replace "\\" "\\\\"
+      >>> replace "\"" "\\\""
+      >>> replace "\n" "\\n"
+      >>> replace "\r" "\\r"
+      >>> replace "\t" "\\t"
+      $ s
+
+  replace from to =
+    String.replaceAll (String.Pattern from) (String.Replacement to)

--- a/test/Sqld/CorpusSpec.purs
+++ b/test/Sqld/CorpusSpec.purs
@@ -1,0 +1,39 @@
+module Test.Sqld.CorpusSpec where
+
+import Prelude
+
+import Data.Array (length, nub) as Array
+import Data.Foldable (for_)
+import Data.String as String
+import Sqld.Format (format, formatInline)
+import Test.Sqld.Corpus (corpus, missingTags)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual, shouldNotEqual)
+
+corpusSpec :: Spec Unit
+corpusSpec = describe "Sqld.Corpus" do
+
+  describe "coverage" do
+    -- If this fails, an AST constructor exists that no corpus entry builds,
+    -- which means PostgreSQL never sees the SQL that constructor emits.
+    it "exercises every required AST constructor" do
+      missingTags `shouldEqual` []
+
+    it "has a non-empty corpus" do
+      Array.length corpus `shouldNotEqual` 0
+
+    it "has unique entry names" do
+      let names = map _.name corpus
+      Array.length (Array.nub names) `shouldEqual` Array.length names
+
+  describe "well-formedness" do
+    for_ corpus \entry -> it entry.name do
+      let
+        formatted = format entry.query
+        placeholders = Array.length (String.split (String.Pattern "$") formatted.sql) - 1
+
+      formatted.sql `shouldNotEqual` ""
+      formatInline entry.query `shouldNotEqual` ""
+      -- Every bound literal must have a placeholder and vice versa; a mismatch
+      -- means `format` would hand the driver the wrong number of parameters.
+      placeholders `shouldEqual` Array.length formatted.params

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1,0 +1,45 @@
+-- Fixture schema for the PostgreSQL validation harness.
+--
+-- Every table and column referenced by `test/Sqld/Corpus.purs` must exist here.
+-- Because the harness validates with PREPARE, PostgreSQL runs full parse
+-- analysis: unknown columns, ambiguous references, invalid GROUP BY and
+-- operator type mismatches all surface as failures. That is stronger than a
+-- syntax check, and it is why the schema is worth maintaining.
+--
+-- WARNING: this file drops and recreates the `public` schema. It is only ever
+-- applied to a throwaway validation database — `scripts/validate-sql.mjs`
+-- refuses to run against a database whose name does not look disposable.
+
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+
+CREATE TABLE users
+  ( id          integer PRIMARY KEY
+  , name        text NOT NULL
+  , email       text
+  , active      boolean NOT NULL DEFAULT true
+  , age         integer
+  , score       numeric
+  , department  text
+  , created_at  timestamptz NOT NULL DEFAULT now()
+  );
+
+CREATE TABLE profiles
+  ( id       integer PRIMARY KEY
+  , user_id  integer NOT NULL REFERENCES users (id)
+  , bio      text
+  );
+
+CREATE TABLE orders
+  ( id        integer PRIMARY KEY
+  , user_id   integer NOT NULL REFERENCES users (id)
+  , status    text NOT NULL
+  , total     numeric NOT NULL
+  , placed_at timestamptz NOT NULL DEFAULT now()
+  );
+
+CREATE TABLE articles
+  ( id           integer PRIMARY KEY
+  , title        text NOT NULL
+  , published_at timestamptz
+  );


### PR DESCRIPTION
Golden tests prove sqld emits the string we expected; they do not prove PostgreSQL accepts it. This adds a second harness that replays every query against a real server.

- test/Sqld/Corpus.purs: one canonical corpus of 35 queries, tagged with the AST constructors each exercises. CorpusSpec fails if any constructor in Sqld.Core has no entry, so coverage cannot silently regress.
- test/Sqld/CorpusEmit.purs: spago test emits test-artifacts/corpus.json.
- scripts/validate-sql.mjs: feeds each query to PostgreSQL via PREPARE, which runs full parse analysis - catching unknown columns, invalid GROUP BY and operator type mismatches, not just bad syntax. Validates both the parameterised form from format and the debug form from formatInline.
- test/fixtures/schema.sql: the tables the corpus references. It drops and recreates public, so the validator refuses to run unless the target database name looks disposable.
- Makefile + scripts/pg-validate-local.sh: local loop against a throwaway Docker container (make validate, validate-fast, sql SQL='...').
- CI gains a postgres:16 service container and runs the harness on every push.