### PR TITLE
:sparkles: exprs, and the mixed select-list idiom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fromRel :: Relation -> Query -> Query` — the general FROM form
 - `starFrom :: String -> SelectExpr` — `"t".*`, previously documented in the README but never implemented
 - `tcols :: String -> Array String -> Array SelectExpr` — columns sharing one table qualifier
+- `select' :: Array SelectExpr -> Query` — starts a query from its select list, so the common case need not name `emptyQuery`. `select` stays additive, so later calls append. Use `emptyQuery` directly for reusable `Query -> Query` fragments, or a query with no select list of its own
 - `exprs :: Array Expr -> Array SelectExpr` — the plural of `expr`, for a run of bare expressions. Mixed select lists concatenate: `cols ["department"] <> [as countStar "headcount"]`. `SelectExpr` stays distinct from `Expr` on purpose — it is what keeps `as` and `star` from type-checking in a `WHERE` clause
 - `notLike` / `notILike`
 - Function wrappers over `app`: `count`, `countStar`, `sum_`, `avg`, `min_`, `max_`, `coalesce`, `lower`, `upper`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fromRel :: Relation -> Query -> Query` — the general FROM form
 - `starFrom :: String -> SelectExpr` — `"t".*`, previously documented in the README but never implemented
 - `tcols :: String -> Array String -> Array SelectExpr` — columns sharing one table qualifier
+- `exprs :: Array Expr -> Array SelectExpr` — the plural of `expr`, for a run of bare expressions. Mixed select lists concatenate: `cols ["department"] <> [as countStar "headcount"]`. `SelectExpr` stays distinct from `Expr` on purpose — it is what keeps `as` and `star` from type-checking in a `WHERE` clause
 - `notLike` / `notILike`
 - Function wrappers over `app`: `count`, `countStar`, `sum_`, `avg`, `min_`, `max_`, `coalesce`, `lower`, `upper`
 - `EXAMPLES.md` — a worked cookbook of 19 examples covering filtering, joins, aggregation, subqueries, derived tables, composition and the `raw` escape hatch. Generated from `Example.Cookbook` by `scripts/build-examples.mjs`, which slices the PureScript out of the source file rather than from a copy, so the code shown is the code that ran. Every example is also a corpus entry, so PostgreSQL validates it; CI fails if the file is stale or the examples drift from the source

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -46,8 +46,7 @@ SQL string — they become numbered parameters, so there is nothing to escape.
 ```purescript
 basicFiltering :: Query
 basicFiltering =
-  emptyQuery
-    # select (cols [ "id", "name", "email" ])
+  select' (cols [ "id", "name", "email" ])
     # from "users"
     # where_ (col "active" .== bool true)
 ```
@@ -72,8 +71,7 @@ what the structure says. Calling `where_` twice ANDs rather than replaces.
 ```purescript
 combiningConditions :: Query
 combiningConditions =
-  emptyQuery
-    # select [ star ]
+  select' [ star ]
     # from "users"
     # where_
         ( and
@@ -104,8 +102,7 @@ is never true in SQL. `coalesce` supplies a fallback.
 ```purescript
 nullHandling :: Query
 nullHandling =
-  emptyQuery
-    # select (cols [ "id" ] <> [ as (coalesce [ col "email", str "(none)" ]) "email" ])
+  select' (cols [ "id" ] <> [ as (coalesce [ col "email", str "(none)" ]) "email" ])
     # from "users"
     # where_ (and [ isNotNull (col "name"), isNull (col "department") ])
 ```
@@ -129,8 +126,7 @@ Bound parameters: `$1` = `"(none)"`
 ```purescript
 patternMatching :: Query
 patternMatching =
-  emptyQuery
-    # select [ star ]
+  select' [ star ]
     # from "users"
     # where_
         ( and
@@ -164,8 +160,7 @@ keeps a select list close to the SQL it produces.
 ```purescript
 joins :: Query
 joins =
-  emptyQuery
-    # select (cols [ "u.name", "p.bio" ])
+  select' (cols [ "u.name", "p.bio" ])
     # fromAs "users" "u"
     # leftJoinAs "profiles" "p" (col "u.id" .== col "p.user_id")
     # innerJoinAs "orders" "o" (and [ col "u.id" .== col "o.user_id", col "o.status" .== str "paid" ])
@@ -192,8 +187,7 @@ of one relation.
 ```purescript
 rightJoinExample :: Query
 rightJoinExample =
-  emptyQuery
-    # select [ starFrom "profiles" ]
+  select' [ starFrom "profiles" ]
     # from "users"
     # rightJoin "profiles" (col "users.id" .== col "profiles.user_id")
 ```
@@ -215,8 +209,7 @@ Keeps unmatched rows from both sides.
 ```purescript
 fullJoinExample :: Query
 fullJoinExample =
-  emptyQuery
-    # select (cols [ "u.name", "p.bio" ])
+  select' (cols [ "u.name", "p.bio" ])
     # fromAs "users" "u"
     # fullJoinAs "profiles" "p" (col "u.id" .== col "p.user_id")
 ```
@@ -239,14 +232,13 @@ alias works exactly as it does in SQL.
 ```purescript
 aggregation :: Query
 aggregation =
-  emptyQuery
-    # select
-        ( cols [ "department" ] <>
-            [ as countStar "headcount"
-            , as (count (col "email")) "with_email"
-            , as (avg (col "age")) "mean_age"
-            ]
-        )
+  select'
+    ( cols [ "department" ] <>
+        [ as countStar "headcount"
+        , as (count (col "email")) "with_email"
+        , as (avg (col "age")) "mean_age"
+        ]
+    )
     # from "users"
     # where_ (col "active" .== bool true)
     # groupBy [ col "department" ]
@@ -278,11 +270,10 @@ Brackets appear only where precedence demands them.
 ```purescript
 functionsAndCasts :: Query
 functionsAndCasts =
-  emptyQuery
-    # select
-        [ as (binOp "||" (col "name") (col "department")) "label"
-        , as (cast (col "id") "text") "id_text"
-        ]
+  select'
+    [ as (binOp "||" (col "name") (col "department")) "label"
+    , as (cast (col "id") "text") "id_text"
+    ]
     # from "users"
     # where_ (binOp "*" (binOp "+" (col "age") (int 1)) (int 2) .> int 40)
 ```
@@ -307,13 +298,11 @@ without joining and de-duplicating.
 ```purescript
 existsExample :: Query
 existsExample =
-  emptyQuery
-    # select [ star ]
+  select' [ star ]
     # fromAs "users" "u"
     # where_
         ( exists
-            ( emptyQuery
-                # select [ expr (raw "1") ]
+            ( select' [ expr (raw "1") ]
                 # from "orders"
                 # where_ (and [ col "orders.user_id" .== col "u.id", col "orders.status" .== str "paid" ])
             )
@@ -340,13 +329,11 @@ never ordered.
 ```purescript
 notExistsExample :: Query
 notExistsExample =
-  emptyQuery
-    # select (tcols "u" [ "id", "name" ])
+  select' (tcols "u" [ "id", "name" ])
     # fromAs "users" "u"
     # where_
         ( notExists
-            ( emptyQuery
-                # select [ expr (raw "1") ]
+            ( select' [ expr (raw "1") ]
                 # from "orders"
                 # where_ (col "orders.user_id" .== col "u.id")
             )
@@ -371,13 +358,11 @@ numbered in step with the outer query.
 ```purescript
 subqueryIn :: Query
 subqueryIn =
-  emptyQuery
-    # select [ star ]
+  select' [ star ]
     # from "users"
     # where_
         ( inSub (col "id")
-            ( emptyQuery
-                # select (cols [ "user_id" ])
+            ( select' (cols [ "user_id" ])
                 # from "orders"
                 # where_ (col "total" .> num 100.0)
             )
@@ -403,20 +388,18 @@ A subquery in the select list, correlated against the outer row.
 ```purescript
 scalarSubquery :: Query
 scalarSubquery =
-  emptyQuery
-    # select
-        ( cols [ "u.name" ] <>
-            [ as
-                ( sub
-                    ( emptyQuery
-                        # select (exprs [ countStar ])
-                        # from "orders"
-                        # where_ (col "orders.user_id" .== col "u.id")
-                    )
+  select'
+    ( cols [ "u.name" ] <>
+        [ as
+            ( sub
+                ( select' (exprs [ countStar ])
+                    # from "orders"
+                    # where_ (col "orders.user_id" .== col "u.id")
                 )
-                "order_count"
-            ]
-        )
+            )
+            "order_count"
+        ]
+    )
     # fromAs "users" "u"
 ```
 
@@ -438,11 +421,9 @@ inside the subquery are numbered before the outer query's.
 ```purescript
 derivedTable :: Query
 derivedTable =
-  emptyQuery
-    # select [ starFrom "paid" ]
+  select' [ starFrom "paid" ]
     # fromSub
-        ( emptyQuery
-            # select (cols [ "id", "user_id", "total" ])
+        ( select' (cols [ "id", "user_id", "total" ])
             # from "orders"
             # where_ (col "status" .== str "paid")
         )
@@ -470,13 +451,11 @@ here, per-user totals computed once and joined back.
 ```purescript
 derivedTableJoin :: Query
 derivedTableJoin =
-  emptyQuery
-    # select (cols [ "u.name", "totals.order_count" ])
+  select' (cols [ "u.name", "totals.order_count" ])
     # fromAs "users" "u"
     # joinOn InnerJoin
         ( derived
-            ( emptyQuery
-                # select (cols [ "user_id" ] <> [ as countStar "order_count" ])
+            ( select' (cols [ "user_id" ] <> [ as countStar "order_count" ])
                 # from "orders"
                 # groupBy [ col "user_id" ]
             )
@@ -506,8 +485,7 @@ paginate pageSize page = limit pageSize >>> offset (pageSize * page)
 
 pagination :: Query
 pagination =
-  emptyQuery
-    # select (cols [ "id", "title" ])
+  select' (cols [ "id", "title" ])
     # from "articles"
     # where_ (isNotNull (col "published_at"))
     # orderBy [ desc (col "published_at"), asc (col "id") ]
@@ -585,7 +563,7 @@ WHERE clauses are ANDed; joins concatenate; scalars take the right-hand side.
 mergingQueries :: Query
 mergingQueries =
   mergeQueries
-    (emptyQuery # select [ star ] # from "users" # where_ (col "active" .== bool true))
+    (select' [ star ] # from "users" # where_ (col "active" .== bool true))
     (emptyQuery # where_ (col "age" .< int 30) # limit 10)
 ```
 
@@ -611,8 +589,7 @@ input. Reach for `app` and `binOp` first.
 ```purescript
 rawEscapeHatch :: Query
 rawEscapeHatch =
-  emptyQuery
-    # select [ colAs "id" "id", as (raw "date_trunc('month', \"created_at\")") "month" ]
+  select' [ colAs "id" "id", as (raw "date_trunc('month', \"created_at\")") "month" ]
     # from "users"
     # where_ (raw "\"created_at\" > NOW() - INTERVAL '30 days'")
 ```

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -105,7 +105,7 @@ is never true in SQL. `coalesce` supplies a fallback.
 nullHandling :: Query
 nullHandling =
   emptyQuery
-    # select [ expr (col "id"), as (coalesce [ col "email", str "(none)" ]) "email" ]
+    # select (cols [ "id" ] <> [ as (coalesce [ col "email", str "(none)" ]) "email" ])
     # from "users"
     # where_ (and [ isNotNull (col "name"), isNull (col "department") ])
 ```
@@ -241,11 +241,12 @@ aggregation :: Query
 aggregation =
   emptyQuery
     # select
-        [ expr (col "department")
-        , as countStar "headcount"
-        , as (count (col "email")) "with_email"
-        , as (avg (col "age")) "mean_age"
-        ]
+        ( cols [ "department" ] <>
+            [ as countStar "headcount"
+            , as (count (col "email")) "with_email"
+            , as (avg (col "age")) "mean_age"
+            ]
+        )
     # from "users"
     # where_ (col "active" .== bool true)
     # groupBy [ col "department" ]
@@ -376,7 +377,7 @@ subqueryIn =
     # where_
         ( inSub (col "id")
             ( emptyQuery
-                # select [ expr (col "user_id") ]
+                # select (cols [ "user_id" ])
                 # from "orders"
                 # where_ (col "total" .> num 100.0)
             )
@@ -404,17 +405,18 @@ scalarSubquery :: Query
 scalarSubquery =
   emptyQuery
     # select
-        [ expr (col "u.name")
-        , as
-            ( sub
-                ( emptyQuery
-                    # select [ expr countStar ]
-                    # from "orders"
-                    # where_ (col "orders.user_id" .== col "u.id")
+        ( cols [ "u.name" ] <>
+            [ as
+                ( sub
+                    ( emptyQuery
+                        # select (exprs [ countStar ])
+                        # from "orders"
+                        # where_ (col "orders.user_id" .== col "u.id")
+                    )
                 )
-            )
-            "order_count"
-        ]
+                "order_count"
+            ]
+        )
     # fromAs "users" "u"
 ```
 
@@ -474,7 +476,7 @@ derivedTableJoin =
     # joinOn InnerJoin
         ( derived
             ( emptyQuery
-                # select [ expr (col "user_id"), as countStar "order_count" ]
+                # select (cols [ "user_id" ] <> [ as countStar "order_count" ])
                 # from "orders"
                 # groupBy [ col "user_id" ]
             )

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Start with `emptyQuery` and pipe through helpers from `Sqld.Select`:
 | Function | Description |
 |---|---|
 | `select :: Array SelectExpr -> Query -> Query` | Append to the SELECT list |
+| `select' :: Array SelectExpr -> Query` | Start a query from its select list, without naming `emptyQuery` |
 | `from :: String -> Query -> Query` | FROM table |
 | `fromAs :: String -> String -> Query -> Query` | FROM with alias |
 | `fromSub :: Query -> String -> Query -> Query` | FROM a derived table (subquery + alias) |
@@ -127,8 +128,7 @@ select (cols ["department"] <> [as countStar "headcount"])
 a fragment contributes columns of its own:
 
 ```purescript
-emptyQuery
-  # select (cols ["department"])
+select' (cols ["department"])
   # select [as countStar "headcount"]
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,35 @@ From `Sqld.Select`:
 | `star` | `select [star]` | `SELECT *` |
 | `cols :: Array String -> Array SelectExpr` | `cols ["u.id", "name"]` | `"u"."id", "name"` |
 | `tcols :: String -> Array String -> Array SelectExpr` | `tcols "u" ["id", "name"]` | `"u"."id", "u"."name"` |
-| `expr :: Expr -> SelectExpr` | `expr (tcol "u" "id")` | `"u"."id"` |
+| `expr :: Expr -> SelectExpr` | `expr (avg (col "age"))` | `AVG("age")` |
+| `exprs :: Array Expr -> Array SelectExpr` | `exprs [col "id", avg (col "age")]` | `"id", AVG("age")` |
 | `as :: Expr -> String -> SelectExpr` | `as (raw "COUNT(*)") "n"` | `COUNT(*) AS "n"` |
 | `colAs :: String -> String -> SelectExpr` | `colAs "created_at" "ts"` | `"created_at" AS "ts"` |
 | `tcolAs :: String -> String -> String -> SelectExpr` | `tcolAs "u" "created_at" "ts"` | `"u"."created_at" AS "ts"` |
 | `starFrom :: String -> SelectExpr` | `starFrom "u"` | `"u".*` |
+
+### Mixed select lists
+
+A PureScript array is homogeneous, so a select list combining plain columns
+with aliased expressions is built by concatenating:
+
+```purescript
+select (cols ["department"] <> [as countStar "headcount"])
+-- SELECT "department", COUNT(*) AS "headcount"
+```
+
+`select` is also additive, so the list can be built up in stages — useful when
+a fragment contributes columns of its own:
+
+```purescript
+emptyQuery
+  # select (cols ["department"])
+  # select [as countStar "headcount"]
+```
+
+Keeping `SelectExpr` distinct from `Expr` is deliberate: it is what stops
+`as` and `star` from type-checking in a `WHERE` clause, where they are not
+valid SQL.
 
 ### Expressions
 

--- a/src/Example/Cookbook.purs
+++ b/src/Example/Cookbook.purs
@@ -24,7 +24,7 @@ import Prelude hiding (between, not, sub)
 import Data.Maybe (Maybe(..), maybe)
 import Sqld.Core (JoinType(..), Query, emptyQuery)
 import Sqld.Expr (and, avg, between, binOp, bool, cast, coalesce, col, count, countStar, exists, ilike, in_, inSub, int, isNotNull, isNull, like, not, notExists, num, or, raw, str, sub, (.<), (.==), (.>), (.>=))
-import Sqld.Select (as, asc, colAs, cols, derived, desc, expr, from, fromAs, fromSub, fullJoinAs, groupBy, having, innerJoinAs, joinOn, leftJoinAs, limit, mergeQueries, offset, orderBy, rightJoin, select, star, starFrom, tcols, where_)
+import Sqld.Select (as, asc, colAs, cols, derived, desc, expr, from, fromAs, fromSub, fullJoinAs, groupBy, having, innerJoinAs, joinOn, leftJoinAs, limit, mergeQueries, offset, exprs, orderBy, rightJoin, select, star, starFrom, tcols, where_)
 
 type Example =
   { name  :: String
@@ -66,7 +66,7 @@ combiningConditions =
 nullHandling :: Query
 nullHandling =
   emptyQuery
-    # select [ expr (col "id"), as (coalesce [ col "email", str "(none)" ]) "email" ]
+    # select (cols [ "id" ] <> [ as (coalesce [ col "email", str "(none)" ]) "email" ])
     # from "users"
     # where_ (and [ isNotNull (col "name"), isNull (col "department") ])
 
@@ -130,11 +130,12 @@ aggregation :: Query
 aggregation =
   emptyQuery
     # select
-        [ expr (col "department")
-        , as countStar "headcount"
-        , as (count (col "email")) "with_email"
-        , as (avg (col "age")) "mean_age"
-        ]
+        ( cols [ "department" ] <>
+            [ as countStar "headcount"
+            , as (count (col "email")) "with_email"
+            , as (avg (col "age")) "mean_age"
+            ]
+        )
     # from "users"
     # where_ (col "active" .== bool true)
     # groupBy [ col "department" ]
@@ -204,7 +205,7 @@ subqueryIn =
     # where_
         ( inSub (col "id")
             ( emptyQuery
-                # select [ expr (col "user_id") ]
+                # select (cols [ "user_id" ])
                 # from "orders"
                 # where_ (col "total" .> num 100.0)
             )
@@ -217,17 +218,18 @@ scalarSubquery :: Query
 scalarSubquery =
   emptyQuery
     # select
-        [ expr (col "u.name")
-        , as
-            ( sub
-                ( emptyQuery
-                    # select [ expr countStar ]
-                    # from "orders"
-                    # where_ (col "orders.user_id" .== col "u.id")
+        ( cols [ "u.name" ] <>
+            [ as
+                ( sub
+                    ( emptyQuery
+                        # select (exprs [ countStar ])
+                        # from "orders"
+                        # where_ (col "orders.user_id" .== col "u.id")
+                    )
                 )
-            )
-            "order_count"
-        ]
+                "order_count"
+            ]
+        )
     # fromAs "users" "u"
 
 -- #example derived-table
@@ -260,7 +262,7 @@ derivedTableJoin =
     # joinOn InnerJoin
         ( derived
             ( emptyQuery
-                # select [ expr (col "user_id"), as countStar "order_count" ]
+                # select (cols [ "user_id" ] <> [ as countStar "order_count" ])
                 # from "orders"
                 # groupBy [ col "user_id" ]
             )

--- a/src/Example/Cookbook.purs
+++ b/src/Example/Cookbook.purs
@@ -24,7 +24,7 @@ import Prelude hiding (between, not, sub)
 import Data.Maybe (Maybe(..), maybe)
 import Sqld.Core (JoinType(..), Query, emptyQuery)
 import Sqld.Expr (and, avg, between, binOp, bool, cast, coalesce, col, count, countStar, exists, ilike, in_, inSub, int, isNotNull, isNull, like, not, notExists, num, or, raw, str, sub, (.<), (.==), (.>), (.>=))
-import Sqld.Select (as, asc, colAs, cols, derived, desc, expr, from, fromAs, fromSub, fullJoinAs, groupBy, having, innerJoinAs, joinOn, leftJoinAs, limit, mergeQueries, offset, exprs, orderBy, rightJoin, select, star, starFrom, tcols, where_)
+import Sqld.Select (as, asc, colAs, cols, derived, desc, expr, from, fromAs, fromSub, fullJoinAs, groupBy, having, innerJoinAs, joinOn, leftJoinAs, limit, mergeQueries, offset, exprs, orderBy, rightJoin, select, select', star, starFrom, tcols, where_)
 
 type Example =
   { name  :: String
@@ -37,8 +37,7 @@ type Example =
 -- SQL string — they become numbered parameters, so there is nothing to escape.
 basicFiltering :: Query
 basicFiltering =
-  emptyQuery
-    # select (cols [ "id", "name", "email" ])
+  select' (cols [ "id", "name", "email" ])
     # from "users"
     # where_ (col "active" .== bool true)
 
@@ -48,8 +47,7 @@ basicFiltering =
 -- what the structure says. Calling `where_` twice ANDs rather than replaces.
 combiningConditions :: Query
 combiningConditions =
-  emptyQuery
-    # select [ star ]
+  select' [ star ]
     # from "users"
     # where_
         ( and
@@ -65,8 +63,7 @@ combiningConditions =
 -- is never true in SQL. `coalesce` supplies a fallback.
 nullHandling :: Query
 nullHandling =
-  emptyQuery
-    # select (cols [ "id" ] <> [ as (coalesce [ col "email", str "(none)" ]) "email" ])
+  select' (cols [ "id" ] <> [ as (coalesce [ col "email", str "(none)" ]) "email" ])
     # from "users"
     # where_ (and [ isNotNull (col "name"), isNull (col "department") ])
 
@@ -75,8 +72,7 @@ nullHandling =
 -- `like` is case-sensitive, `ilike` is not. `between` is inclusive at both ends.
 patternMatching :: Query
 patternMatching =
-  emptyQuery
-    # select [ star ]
+  select' [ star ]
     # from "users"
     # where_
         ( and
@@ -95,8 +91,7 @@ patternMatching =
 -- keeps a select list close to the SQL it produces.
 joins :: Query
 joins =
-  emptyQuery
-    # select (cols [ "u.name", "p.bio" ])
+  select' (cols [ "u.name", "p.bio" ])
     # fromAs "users" "u"
     # leftJoinAs "profiles" "p" (col "u.id" .== col "p.user_id")
     # innerJoinAs "orders" "o" (and [ col "u.id" .== col "o.user_id", col "o.status" .== str "paid" ])
@@ -107,8 +102,7 @@ joins =
 -- of one relation.
 rightJoinExample :: Query
 rightJoinExample =
-  emptyQuery
-    # select [ starFrom "profiles" ]
+  select' [ starFrom "profiles" ]
     # from "users"
     # rightJoin "profiles" (col "users.id" .== col "profiles.user_id")
 
@@ -117,8 +111,7 @@ rightJoinExample =
 -- Keeps unmatched rows from both sides.
 fullJoinExample :: Query
 fullJoinExample =
-  emptyQuery
-    # select (cols [ "u.name", "p.bio" ])
+  select' (cols [ "u.name", "p.bio" ])
     # fromAs "users" "u"
     # fullJoinAs "profiles" "p" (col "u.id" .== col "p.user_id")
 
@@ -128,14 +121,13 @@ fullJoinExample =
 -- alias works exactly as it does in SQL.
 aggregation :: Query
 aggregation =
-  emptyQuery
-    # select
-        ( cols [ "department" ] <>
-            [ as countStar "headcount"
-            , as (count (col "email")) "with_email"
-            , as (avg (col "age")) "mean_age"
-            ]
-        )
+  select'
+    ( cols [ "department" ] <>
+        [ as countStar "headcount"
+        , as (count (col "email")) "with_email"
+        , as (avg (col "age")) "mean_age"
+        ]
+    )
     # from "users"
     # where_ (col "active" .== bool true)
     # groupBy [ col "department" ]
@@ -149,11 +141,10 @@ aggregation =
 -- Brackets appear only where precedence demands them.
 functionsAndCasts :: Query
 functionsAndCasts =
-  emptyQuery
-    # select
-        [ as (binOp "||" (col "name") (col "department")) "label"
-        , as (cast (col "id") "text") "id_text"
-        ]
+  select'
+    [ as (binOp "||" (col "name") (col "department")) "label"
+    , as (cast (col "id") "text") "id_text"
+    ]
     # from "users"
     # where_ (binOp "*" (binOp "+" (col "age") (int 1)) (int 2) .> int 40)
 
@@ -163,13 +154,11 @@ functionsAndCasts =
 -- without joining and de-duplicating.
 existsExample :: Query
 existsExample =
-  emptyQuery
-    # select [ star ]
+  select' [ star ]
     # fromAs "users" "u"
     # where_
         ( exists
-            ( emptyQuery
-                # select [ expr (raw "1") ]
+            ( select' [ expr (raw "1") ]
                 # from "orders"
                 # where_ (and [ col "orders.user_id" .== col "u.id", col "orders.status" .== str "paid" ])
             )
@@ -181,13 +170,11 @@ existsExample =
 -- never ordered.
 notExistsExample :: Query
 notExistsExample =
-  emptyQuery
-    # select (tcols "u" [ "id", "name" ])
+  select' (tcols "u" [ "id", "name" ])
     # fromAs "users" "u"
     # where_
         ( notExists
-            ( emptyQuery
-                # select [ expr (raw "1") ]
+            ( select' [ expr (raw "1") ]
                 # from "orders"
                 # where_ (col "orders.user_id" .== col "u.id")
             )
@@ -199,13 +186,11 @@ notExistsExample =
 -- numbered in step with the outer query.
 subqueryIn :: Query
 subqueryIn =
-  emptyQuery
-    # select [ star ]
+  select' [ star ]
     # from "users"
     # where_
         ( inSub (col "id")
-            ( emptyQuery
-                # select (cols [ "user_id" ])
+            ( select' (cols [ "user_id" ])
                 # from "orders"
                 # where_ (col "total" .> num 100.0)
             )
@@ -216,20 +201,18 @@ subqueryIn =
 -- A subquery in the select list, correlated against the outer row.
 scalarSubquery :: Query
 scalarSubquery =
-  emptyQuery
-    # select
-        ( cols [ "u.name" ] <>
-            [ as
-                ( sub
-                    ( emptyQuery
-                        # select (exprs [ countStar ])
-                        # from "orders"
-                        # where_ (col "orders.user_id" .== col "u.id")
-                    )
+  select'
+    ( cols [ "u.name" ] <>
+        [ as
+            ( sub
+                ( select' (exprs [ countStar ])
+                    # from "orders"
+                    # where_ (col "orders.user_id" .== col "u.id")
                 )
-                "order_count"
-            ]
-        )
+            )
+            "order_count"
+        ]
+    )
     # fromAs "users" "u"
 
 -- #example derived-table
@@ -239,11 +222,9 @@ scalarSubquery =
 -- inside the subquery are numbered before the outer query's.
 derivedTable :: Query
 derivedTable =
-  emptyQuery
-    # select [ starFrom "paid" ]
+  select' [ starFrom "paid" ]
     # fromSub
-        ( emptyQuery
-            # select (cols [ "id", "user_id", "total" ])
+        ( select' (cols [ "id", "user_id", "total" ])
             # from "orders"
             # where_ (col "status" .== str "paid")
         )
@@ -256,13 +237,11 @@ derivedTable =
 -- here, per-user totals computed once and joined back.
 derivedTableJoin :: Query
 derivedTableJoin =
-  emptyQuery
-    # select (cols [ "u.name", "totals.order_count" ])
+  select' (cols [ "u.name", "totals.order_count" ])
     # fromAs "users" "u"
     # joinOn InnerJoin
         ( derived
-            ( emptyQuery
-                # select (cols [ "user_id" ] <> [ as countStar "order_count" ])
+            ( select' (cols [ "user_id" ] <> [ as countStar "order_count" ])
                 # from "orders"
                 # groupBy [ col "user_id" ]
             )
@@ -279,8 +258,7 @@ paginate pageSize page = limit pageSize >>> offset (pageSize * page)
 
 pagination :: Query
 pagination =
-  emptyQuery
-    # select (cols [ "id", "title" ])
+  select' (cols [ "id", "title" ])
     # from "articles"
     # where_ (isNotNull (col "published_at"))
     # orderBy [ desc (col "published_at"), asc (col "id") ]
@@ -324,7 +302,7 @@ composingFragments = searchUsers (Just "engineering") (Just "@example.com") 1
 mergingQueries :: Query
 mergingQueries =
   mergeQueries
-    (emptyQuery # select [ star ] # from "users" # where_ (col "active" .== bool true))
+    (select' [ star ] # from "users" # where_ (col "active" .== bool true))
     (emptyQuery # where_ (col "age" .< int 30) # limit 10)
 
 -- #example raw-escape-hatch
@@ -334,8 +312,7 @@ mergingQueries =
 -- input. Reach for `app` and `binOp` first.
 rawEscapeHatch :: Query
 rawEscapeHatch =
-  emptyQuery
-    # select [ colAs "id" "id", as (raw "date_trunc('month', \"created_at\")") "month" ]
+  select' [ colAs "id" "id", as (raw "date_trunc('month', \"created_at\")") "month" ]
     # from "users"
     # where_ (raw "\"created_at\" > NOW() - INTERVAL '30 days'")
 

--- a/src/Sqld/Select.purs
+++ b/src/Sqld/Select.purs
@@ -3,7 +3,7 @@ module Sqld.Select where
 import Data.Array (null) as Array
 import Data.Maybe (Maybe(..))
 import Prelude (($), (<<<), (<>), map)
-import Sqld.Core (Expr(..), JoinType(..), OrderDir(..), OrderExpr, Query, Relation(..), SelectExpr(..))
+import Sqld.Core (Expr(..), JoinType(..), OrderDir(..), OrderExpr, Query, Relation(..), SelectExpr(..), emptyQuery)
 import Sqld.Expr (col, tcol)
 
 -- ---------------------------------------------------------------------------
@@ -44,6 +44,17 @@ fromSub sub alias = fromRel $ derived sub alias
 
 select :: Array SelectExpr -> Query -> Query
 select exprs q = q { select = q.select <> exprs }
+
+-- | Starts a query from its select list, so the common case need not name
+-- | `emptyQuery`:
+-- |
+-- |     select' (cols [ "id", "name" ]) # from "users"
+-- |
+-- | `select` is additive, so further `select` calls append as usual. Build
+-- | reusable `Query -> Query` fragments with `select` and apply them to
+-- | `emptyQuery` at the end.
+select' :: Array SelectExpr -> Query
+select' exprs = select exprs emptyQuery
 
 where_ :: Expr -> Query -> Query
 where_ e q = q { where_ = Just $ case q.where_ of

--- a/src/Sqld/Select.purs
+++ b/src/Sqld/Select.purs
@@ -120,6 +120,17 @@ starFrom = SelectStarFrom
 expr :: Expr -> SelectExpr
 expr = SelectExpr
 
+-- | The plural of `expr`, for a run of bare expressions.
+-- |
+-- | A PureScript array is homogeneous, so a select list mixing bare and
+-- | aliased items is built by concatenating:
+-- |
+-- |     select (cols [ "department" ] <> [ as countStar "headcount" ])
+-- |
+-- | `select` is also additive, so repeated calls append rather than replace.
+exprs :: Array Expr -> Array SelectExpr
+exprs = map SelectExpr
+
 -- | Plain column references. Names may be dot-qualified: `cols [ "u.id" ]`
 -- | renders `"u"."id"`.
 cols :: Array String -> Array SelectExpr

--- a/test/Sqld/Corpus.purs
+++ b/test/Sqld/Corpus.purs
@@ -27,8 +27,8 @@ import Data.Array (concatMap, difference, nub, null, sort) as Array
 import Data.Maybe (Maybe(..), isJust)
 import Example.Cookbook (cookbook) as Cookbook
 import Sqld.Core (Expr(..), JoinType(..), Literal(..), OrderDir(..), OrderExpr, Query, Relation(..), SelectExpr(..), emptyQuery)
-import Sqld.Expr (and, between, binOp, bool, cast, coalesce, col, count, countStar, exists, ilike, in_, inSub, int, isNotNull, isNull, like, not, notExists, notILike, notIn, notInSub, notLike, null, num, or, raw, str, sub, tcol, upper, (.!=), (.<), (.<=), (.==), (.>), (.>=))
-import Sqld.Select (as, asc, colAs, cols, derived, desc, expr, from, fromAs, fromSub, fullJoinAs, groupBy, having, innerJoin, joinOn, leftJoinAs, limit, offset, orderBy, rightJoin, select, star, starFrom, tcolAs, tcols, where_)
+import Sqld.Expr (and, avg, between, binOp, bool, cast, coalesce, col, count, countStar, exists, ilike, in_, inSub, int, isNotNull, isNull, like, not, notExists, notILike, notIn, notInSub, notLike, null, num, or, raw, str, sub, tcol, upper, (.!=), (.<), (.<=), (.==), (.>), (.>=))
+import Sqld.Select (as, asc, colAs, cols, derived, desc, expr, exprs, from, fromAs, fromSub, fullJoinAs, groupBy, having, innerJoin, joinOn, leftJoinAs, limit, offset, orderBy, rightJoin, select, star, starFrom, tcolAs, tcols, where_)
 
 type CorpusEntry = { name :: String, query :: Query }
 
@@ -419,6 +419,15 @@ handWritten =
                     # where_ (tcol "orders" "user_id" .== tcol "u" "id")
                 )
             )
+    }
+
+  -- Select-list composition ---------------------------------------------------
+
+  , { name: "mixed-select-list"
+    , query: emptyQuery
+        # select (cols [ "department" ] <> exprs [ avg (col "age") ] <> [ as countStar "headcount" ])
+        # from "users"
+        # groupBy [ col "department" ]
     }
 
   -- Dot-qualified column references ------------------------------------------

--- a/test/Sqld/SelectSpec.purs
+++ b/test/Sqld/SelectSpec.purs
@@ -75,6 +75,33 @@ selectSpec = describe "Sqld.Select" do
             # formatInline
       query `shouldEqual` "SELECT \"dept\", COUNT(*) AS \"n\" FROM \"t\""
 
+  describe "mixed select lists" do
+    it "concatenates plain columns with aliased expressions" do
+      let query = emptyQuery
+            # select (cols ["department"] <> [as countStar "headcount"])
+            # from "users"
+            # groupBy [col "department"]
+            # formatInline
+      query `shouldEqual`
+        "SELECT \"department\", COUNT(*) AS \"headcount\" FROM \"users\" GROUP BY \"department\""
+
+    it "exprs wraps a run of bare expressions" do
+      let query = emptyQuery
+            # select (exprs [col "id", avg (col "age")])
+            # from "users"
+            # formatInline
+      query `shouldEqual` "SELECT \"id\", AVG(\"age\") FROM \"users\""
+
+    it "select is additive, so lists can be built up in stages" do
+      let query = emptyQuery
+            # select (cols ["department"])
+            # select [as countStar "headcount"]
+            # from "users"
+            # groupBy [col "department"]
+            # formatInline
+      query `shouldEqual`
+        "SELECT \"department\", COUNT(*) AS \"headcount\" FROM \"users\" GROUP BY \"department\""
+
   describe "FROM clause" do
     it "bare table" do
       let query = emptyQuery

--- a/test/Sqld/SelectSpec.purs
+++ b/test/Sqld/SelectSpec.purs
@@ -75,6 +75,28 @@ selectSpec = describe "Sqld.Select" do
             # formatInline
       query `shouldEqual` "SELECT \"dept\", COUNT(*) AS \"n\" FROM \"t\""
 
+  describe "select'" do
+    it "starts a query without naming emptyQuery" do
+      let query = select' (cols ["id", "name"])
+            # from "users"
+            # where_ (col "active" .== bool true)
+            # formatInline
+      query `shouldEqual` "SELECT \"id\", \"name\" FROM \"users\" WHERE \"active\" = TRUE"
+
+    it "stays additive, so later select calls append" do
+      let query = select' (cols ["department"])
+            # select [as countStar "headcount"]
+            # from "users"
+            # groupBy [col "department"]
+            # formatInline
+      query `shouldEqual`
+        "SELECT \"department\", COUNT(*) AS \"headcount\" FROM \"users\" GROUP BY \"department\""
+
+    it "matches the emptyQuery form exactly" do
+      let viaHelper = select' (cols ["id"]) # from "users" # formatInline
+          viaEmpty  = emptyQuery # select (cols ["id"]) # from "users" # formatInline
+      viaHelper `shouldEqual` viaEmpty
+
   describe "mixed select lists" do
     it "concatenates plain columns with aliased expressions" do
       let query = emptyQuery


### PR DESCRIPTION
Measuring first changed the plan. Every remaining `expr` call in the cookbook wrapped a plain column or a raw fragment - none wrapped a computed expression, because those get aliased anyway. The ceremony was concentrated in mixed select lists, where some items are plain columns and some are aliased, and a homogeneous PureScript array forces a wrapper on the plain ones.

So rather than unifying SelectExpr into Expr:

  select (cols [ "department" ] <> [ as countStar "headcount" ])

Adds exprs :: Array Expr -> Array SelectExpr for a run of bare expressions, and documents both the <> idiom and the fact that select is additive, which already worked and was written down nowhere.

SelectExpr stays distinct from Expr deliberately. Unifying would make where_ (as e "x") and where_ star compile into invalid SQL, giving up the same guarantee that made Derived carry a mandatory String alias rather than a Maybe. Terser select lists are not worth that inconsistency.

Cookbook expr calls: 7 -> 2, both now `expr (raw "1")`, a single bare item in an EXISTS subquery, which is what expr is for. The SQL every example emits is byte-for-byte unchanged.

151 tests, 74 corpus queries green against PostgreSQL 16.