### PR TITLE
:bug: An empty IN list folds to a constant, not IN ()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `select` is now additive — calling it multiple times appends to the select list rather than replacing it
 - Table aliases now render with explicit `AS` keyword (`FROM "users" AS "u"` instead of `FROM "users" "u"`)
 - Implicit `SELECT *` removed — use `select [star]` explicitly
+
+### Fixed
+- `in_` with an empty candidate list folds to `FALSE`, and `notIn` to `TRUE`, instead of emitting `IN ()` / `NOT IN ()` — a syntax error PostgreSQL rejects at execution time rather than at the call site. An empty list arises naturally when a filter is driven by user input. The fold happens in `Sqld.Expr`, so `Row []` stays representable for anyone building the AST directly, and the constant is a bare keyword, so it needs no bracketing under `AND` / `OR` / `NOT`. Non-empty lists and `inSub` / `notInSub` are unchanged

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ From `Sqld.Expr`:
 | `not :: Expr -> Expr` | `not e` | `NOT e` |
 | `isNull / isNotNull` | `isNull (col "deleted_at")` | `"deleted_at" IS NULL` |
 | `in_ :: Expr -> Array Expr -> Expr` | `in_ (col "id") [int 1, int 2]` | `"id" IN ($1, $2)` |
+| `in_` with an empty list | `in_ (col "id") []` | `FALSE` |
 | `notIn` | `notIn (col "s") [str "x"]` | `"s" NOT IN ($1)` |
+| `notIn` with an empty list | `notIn (col "s") []` | `TRUE` |
 | `between` | `between (col "n") (int 1) (int 10)` | `"n" BETWEEN $1 AND $2` |
 | `like / ilike` | `like (col "email") "%@acme.com"` | `"email" LIKE $1` |
 | `notLike / notILike` | `notLike (col "email") "%@spam.com"` | `"email" NOT LIKE $1` |

--- a/src/Sqld/Expr.purs
+++ b/src/Sqld/Expr.purs
@@ -146,11 +146,21 @@ isNotNull = Postfix "IS NOT NULL"
 -- Set membership
 -- ---------------------------------------------------------------------------
 
+-- | `e IN (a, b, …)`.
+-- |
+-- | An empty candidate list folds to `FALSE`: nothing is a member of the empty
+-- | set, and `IN ()` is a syntax error PostgreSQL rejects. `Or []` is that
+-- | constant — it already renders as the bare keyword `FALSE`, which is an atom
+-- | the precedence printer never needs to bracket.
 in_ :: Expr -> Array Expr -> Expr
-in_ e = BinOp "IN" e <<< Row
+in_ _ [] = Or []
+in_ e xs = BinOp "IN" e (Row xs)
 
+-- | `e NOT IN (a, b, …)`. The mirror of `in_`: an empty candidate list folds to
+-- | `TRUE`, since everything is a non-member of the empty set.
 notIn :: Expr -> Array Expr -> Expr
-notIn e = BinOp "NOT IN" e <<< Row
+notIn _ [] = And []
+notIn e xs = BinOp "NOT IN" e (Row xs)
 
 -- | `e IN (SELECT …)`.
 inSub :: Expr -> Query -> Expr

--- a/test/Sqld/Corpus.purs
+++ b/test/Sqld/Corpus.purs
@@ -175,6 +175,38 @@ handWritten =
         # where_ (notIn (col "id") [ int 1, int 2, int 3 ])
     }
 
+  -- An empty candidate list folds to a constant rather than emitting `IN ()`,
+  -- which PostgreSQL rejects. These entries are here to prove that: without the
+  -- fold, PREPARE fails on them.
+  , { name: "in-list-empty"
+    , query: emptyQuery
+        # select [ star ]
+        # from "users"
+        # where_ (in_ (col "department") [])
+    }
+
+  , { name: "not-in-list-empty"
+    , query: emptyQuery
+        # select [ star ]
+        # from "users"
+        # where_ (notIn (col "id") [])
+    }
+
+  -- The folded constant under AND / OR / NOT — the positions where bracketing
+  -- would change the meaning if it were not an atom.
+  , { name: "in-list-empty-nested"
+    , query: emptyQuery
+        # select [ star ]
+        # from "users"
+        # where_
+            ( and
+                [ col "active" .== bool true
+                , or [ in_ (col "department") [], notIn (col "id") [] ]
+                , not (in_ (col "email") [])
+                ]
+            )
+    }
+
   -- Pattern matching ---------------------------------------------------------
 
   , { name: "like"

--- a/test/Sqld/ExprSpec.purs
+++ b/test/Sqld/ExprSpec.purs
@@ -154,6 +154,55 @@ exprSpec = describe "Sqld.Expr" do
             # formatInline
       query `shouldEqual` "SELECT * FROM \"t\" WHERE \"status\" NOT IN ('deleted', 'banned')"
 
+    -- "id" IN () is a syntax error, so an empty list folds to the constant it
+    -- means: nothing is a member of the empty set.
+    it "IN with an empty list produces FALSE" do
+      let query = emptyQuery
+            # select [star]
+            # from "t"
+            # where_ ((col "id") `in_` [])
+            # formatInline
+      query `shouldEqual` "SELECT * FROM \"t\" WHERE FALSE"
+
+    it "NOT IN with an empty list produces TRUE" do
+      let query = emptyQuery
+            # select [star]
+            # from "t"
+            # where_ ((col "id") `notIn` [])
+            # formatInline
+      query `shouldEqual` "SELECT * FROM \"t\" WHERE TRUE"
+
+    -- The folded constant sits under AND, OR and NOT in turn: each is a
+    -- position where a badly bracketed operand would change the meaning.
+    it "the folded constant is bracket-safe as an operand" do
+      let query = emptyQuery
+            # select [star]
+            # from "t"
+            # where_
+                (and [ col "active" .== bool true
+                     , or [ (col "id") `in_` [], (col "flag") `notIn` [] ]
+                     , not ((col "id") `in_` [])
+                     ])
+            # formatInline
+      query `shouldEqual`
+        "SELECT * FROM \"t\" WHERE (\"active\" = TRUE AND (FALSE OR TRUE) AND NOT FALSE)"
+
+    -- Folding must not consume a parameter slot, or every binding after it
+    -- shifts by one.
+    it "folding leaves parameter numbering untouched" do
+      let result = emptyQuery
+            # select [star]
+            # from "t"
+            # where_
+                (and [ col "a" .== int 1
+                     , (col "id") `in_` []
+                     , col "b" .== int 2
+                     ])
+            # format
+      result.sql `shouldEqual`
+        "SELECT * FROM \"t\" WHERE (\"a\" = $1 AND FALSE AND \"b\" = $2)"
+      result.params `shouldEqual` [LitInt 1, LitInt 2]
+
     it "BETWEEN" do
       let query = emptyQuery
             # select [star]


### PR DESCRIPTION
Closes #5

`in_ (col "id") []` emitted `"id" IN ()`, which PostgreSQL rejects with a syntax error; `notIn` emitted `NOT IN ()`. An empty candidate list arises naturally when a filter is driven by user input, so the failure surfaced at the database rather than the call site.

## The fold

```purescript
in_ (col "id") []      -- FALSE   (nothing is a member of the empty set)
notIn (col "id") []    -- TRUE    (everything is a non-member)
```

Both reuse constants `Sqld.Expr` already has rather than inventing new ones: `Or []` already renders as the bare keyword `FALSE`, `And []` as `TRUE`. That is the precedent `and []` / `or []` set, and it keeps the fold in `Sqld.Expr` — so `Row []` stays representable for anyone building the AST directly, and no catch-all case is added to any formatter.

Both constants are atoms as far as `precOf` is concerned, so the precedence printer never brackets them:

```sql
SELECT * FROM "users" WHERE ("active" = $1 AND (FALSE OR TRUE) AND NOT FALSE)
```

Neither consumes a parameter slot, so bindings after a folded operand keep their numbering. Non-empty lists are unchanged, as are `inSub` / `notInSub`.

## Considered: `NonEmptyArray`

Making the empty case unrepresentable was the obvious alternative, and `arrays` is already a dependency. Rejected, because `NEA.fromArray` returns a `Maybe` — so for the motivating case (a list computed from user input) the type relocates the decision to every call site rather than removing it, and each site has to independently rediscover that the empty branch means `FALSE`, and `TRUE` for `notIn`. It would also break every literal call site, including the cookbook's, and leave `in_` demanding proof-of-non-emptiness while its neighbours `and` / `or` fold. The empty case has a well-defined meaning, so it is not an illegal state.

## Acceptance criteria

- [x] Builder exposed from `Sqld.Expr` — `in_` / `notIn`, signatures unchanged
- [x] `Sqld.Format` renders it; no catch-all case added to any formatter — no formatter change needed
- [x] Golden tests asserting the exact emitted string, including bracketing — 4 new in `ExprSpec`
- [x] Corpus entries for both the empty and non-empty forms — `in-list-empty`, `not-in-list-empty`, `in-list-empty-nested`; existing `in-list` / `not-in-list` cover non-empty
- [x] Any new table or column added to `test/fixtures/schema.sql` — none needed, reuses `users`
- [x] New AST constructors tagged and listed in `requiredTags` — no new constructors; folded forms tag as the already-required `Expr.And.empty` / `Expr.Or.empty`
- [x] Parameter numbering follows emitted-SQL order, with a test — `folding leaves parameter numbering untouched`
- [x] README API table updated
- [x] `CHANGELOG.md` updated under `[Unreleased]`

## Verification

- `spago test` — 161/161 pass
- `make validate` — 77/77 through real PostgreSQL `PREPARE`, including the three new entries. Without the fold these three fail
- `make examples-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)