### PR TITLE
:memo: Community health files: conduct, contributing, security, templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Wrong SQL, wrong params, or a compile error from the library
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing. The most useful bug report here is a small `Query`
+        plus the SQL it produced.
+
+        If this is a **security** issue — a value that should have been
+        parameterised but was interpolated, or an identifier that escaped its
+        quotes — please do not file it here. See
+        [SECURITY.md](https://github.com/plooney81/purescript-sqld/blob/main/SECURITY.md).
+
+  - type: textarea
+    id: query
+    attributes:
+      label: The query
+      description: The smallest PureScript snippet that reproduces it.
+      render: purescript
+      placeholder: |
+        select' (cols ["id", "name"])
+          # from "users"
+          # where_ (col "id" .== int 42)
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What `format` returned
+      description: The `sql` string and `params` array, or the compiler error.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+
+  - type: dropdown
+    id: postgres
+    attributes:
+      label: Does PostgreSQL accept the emitted SQL?
+      description: "`make sql SQL='...'` answers this in a few seconds."
+      options:
+        - "No — PostgreSQL rejects it"
+        - "Yes — it parses, but it is the wrong query"
+        - "Haven't checked"
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Commit or version
+      description: "`git rev-parse --short HEAD`, since nothing is published yet."
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: PureScript/spago versions, workarounds you found, related issues.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or idea
+    url: https://github.com/plooney81/purescript-sqld/discussions
+    about: Usage questions and open-ended design discussion belong in Discussions.
+  - name: Report a security vulnerability
+    url: https://github.com/plooney81/purescript-sqld/security/advisories/new
+    about: Please report injection or quoting-escape issues privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: A SQL construct sqld cannot build, or a builder that should exist
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        `sqld` is PostgreSQL-only and currently SELECT-only, on purpose. Requests
+        for other dialects will likely be declined; other statement types are
+        open for discussion.
+
+  - type: textarea
+    id: sql
+    attributes:
+      label: The SQL you want to produce
+      render: sql
+      placeholder: |
+        SELECT "id", lag("total") OVER (PARTITION BY "user_id" ORDER BY "day")
+        FROM "orders"
+    validations:
+      required: true
+
+  - type: textarea
+    id: api
+    attributes:
+      label: How you imagine building it
+      description: >
+        A sketch of the builder API. Rough is fine — the shape matters more than
+        the names. Remember every builder is `Query -> Query`.
+      render: purescript
+
+  - type: dropdown
+    id: workaround
+    attributes:
+      label: Can you get there with `raw` today?
+      options:
+        - "Yes, but it is awkward enough to want a builder"
+        - "Yes, and it is fine — filing this for completeness"
+        - "No — `raw` cannot express it"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: Links to the PostgreSQL docs for the construct, prior art in HoneySQL, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## What this changes
+
+<!-- One or two sentences. Link the issue if there is one: Closes #123 -->
+
+## SQL before / after
+
+<!-- If this changes emitted SQL, show it. Delete this section if it doesn't. -->
+
+```sql
+-- before
+
+-- after
+```
+
+## Checklist
+
+- [ ] `make validate` passes locally (tests **and** replay against PostgreSQL)
+- [ ] New `Sqld.Core` constructors have a `test/Sqld/Corpus.purs` entry
+- [ ] Any new tables/columns exist in `test/fixtures/schema.sql`
+- [ ] `make examples-check` passes, or `EXAMPLES.md` was regenerated via `make examples`
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`
+
+## Notes for the reviewer
+
+<!-- Trade-offs, alternatives you rejected, anything you're unsure about. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**petelooney81@gmail.com**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing to sqld
+
+Thanks for taking a look. `sqld` is a PostgreSQL query builder for PureScript:
+queries are plain data, builders are `Query -> Query`, and `format` is pure.
+Contributions that keep those properties are very welcome.
+
+By participating you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Getting set up
+
+You need the PureScript toolchain, Node 20+, and Docker (for the validation
+harness).
+
+```
+npm install -g purescript spago
+spago install
+make build
+```
+
+`make` on its own lists every target with a one-line description.
+
+## The development loop
+
+```
+make build           # compile
+make test            # golden tests; also emits test-artifacts/corpus.json
+make validate        # tests, then replay every query against real PostgreSQL
+make validate-fast   # skip spago test, reuse the warm container
+```
+
+Narrow a validation run while iterating, or probe a query without adding a
+corpus entry at all:
+
+```
+make list                          # corpus entry names
+make validate-fast ONLY=join       # only entries matching "join"
+make sql SQL='SELECT "u".* FROM "users" AS "u"'
+```
+
+`make sql` is the fastest way to answer "will PostgreSQL accept this?" during a
+formatter change. `make pg-stop` removes the container when you are done.
+
+## The rule that shapes most changes
+
+Golden tests prove `format` emits the string we expected. The validation
+harness proves PostgreSQL actually accepts that string. **Both must pass, and a
+new feature cannot ship without a corpus entry.**
+
+`test/Sqld/Corpus.purs` is the single corpus both harnesses consume. Each entry
+is tagged with the AST constructors it exercises, and `Test.Sqld.CorpusSpec`
+fails if any constructor in `Sqld.Core` has no entry.
+
+So when you add a constructor to `Sqld.Core`:
+
+1. The tagging functions in the corpus become non-exhaustive — the compiler
+   tells you exactly where.
+2. Tag the new constructor, and the coverage assertion then fails until a corpus
+   entry actually exercises it.
+3. Add the entry. Every table and column it references must exist in
+   `test/fixtures/schema.sql` — add them there if not.
+4. Run `make validate` and confirm PostgreSQL accepts the emitted SQL.
+
+This is deliberate friction. It is why the README can claim every documented
+query has been run against a real server.
+
+## Documentation that is generated
+
+`EXAMPLES.md` is generated from `src/Example/Cookbook.purs` — do not edit it by
+hand. Change the cookbook, then:
+
+```
+make examples        # regenerate
+make examples-check  # fail if stale (this is what CI runs)
+```
+
+Add a `CHANGELOG.md` entry under `## [Unreleased]` for anything user-visible.
+
+## Style
+
+- **`where` clauses over `let` bindings** for helper definitions.
+- **Point-free composition with `<<<`** where it reads more clearly than a
+  lambda; do not contort code to achieve it.
+- Match the surrounding module — comment density and naming included.
+- No implicit `SELECT *`; no string interpolation of literals. Values become
+  numbered params, identifiers get quoted.
+
+## Commits and pull requests
+
+Commit messages use a [gitmoji](https://gitmoji.dev) prefix and an imperative
+summary:
+
+```
+:sparkles: Window functions (OVER, PARTITION BY, frames)
+:bug: An empty IN list folds to a constant, not IN ()
+:recycle: Collapse the expression AST onto generic nodes
+:memo: Worked example cookbook, generated and PostgreSQL-validated
+:white_check_mark: Validate emitted SQL against real PostgreSQL
+:art: Point-free helpers and where clauses over let bindings
+```
+
+Before opening a pull request:
+
+- [ ] `make validate` passes locally
+- [ ] `make examples-check` passes (or you regenerated `EXAMPLES.md`)
+- [ ] new AST constructors have corpus entries
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`
+
+CI runs the same steps against PostgreSQL 16 on every push and pull request.
+
+## Scope
+
+`sqld` is PostgreSQL-only and currently SELECT-only, on purpose. Proposals for
+other dialects will likely be declined; proposals for other statement types
+(INSERT, UPDATE, DELETE) are interesting — please open an issue to discuss the
+shape before writing much code.
+
+`raw` exists as the escape hatch for anything the builders do not cover. If you
+find yourself reaching for it often for the same construct, that is a good issue
+to file.

--- a/README.md
+++ b/README.md
@@ -472,6 +472,15 @@ new tag then fails the coverage assertion until a corpus entry exists.
 Every table and column the corpus references must exist in
 `test/fixtures/schema.sql`.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development loop, the corpus
+coverage rule a new feature has to satisfy, and the commit conventions.
+Participation is covered by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+To report a suspected injection or quoting-escape issue, follow
+[SECURITY.md](SECURITY.md) rather than opening a public issue.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Supported versions
+
+`sqld` is pre-1.0 and not yet published to the PureScript registry. Only the
+latest commit on `main` receives fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| `main`  | ✅        |
+| Older tags / forks | ❌ |
+
+## What counts as a security issue here
+
+`sqld` is a pure query builder: it turns a `Query` value into a SQL string and
+an array of parameters. It never opens a connection and never executes
+anything. The security-relevant surface is therefore narrow but real:
+
+- **Injection through a value that should have been parameterised.** Every
+  literal is meant to become a numbered param (`$1`, `$2`, …). If any input path
+  ends up interpolated into the SQL string instead, that is a vulnerability.
+- **Injection through identifier quoting.** Table, column, and alias names are
+  quoted. A name that escapes its quotes — via an embedded `"`, a null byte, or
+  any other input — is a vulnerability.
+- **Param numbering or ordering bugs** that cause a value to bind to the wrong
+  placeholder, since that can silently defeat an authorisation predicate in a
+  `WHERE` clause.
+
+Not security issues:
+
+- `raw` emitting exactly what you passed it. `raw` is a documented escape hatch
+  that opts out of quoting; passing untrusted input to it is a bug in the
+  calling code.
+- `formatInline` / `formatPretty` substituting values into the string. These are
+  documented as debugging and logging helpers and must never be handed to a
+  driver.
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for a suspected vulnerability.
+
+Report it privately using GitHub's
+[private vulnerability reporting](https://github.com/plooney81/purescript-sqld/security/advisories/new),
+or by email to **petelooney81@gmail.com**.
+
+Please include:
+
+- the PureScript snippet that builds the `Query`,
+- the SQL string and params `format` returned,
+- what you expected instead, and
+- why the difference is exploitable, if it is not obvious.
+
+## What to expect
+
+- **Acknowledgement** within 7 days.
+- **An assessment** — confirmed, needs more information, or not a vulnerability
+  — within 14 days.
+- **A fix on `main`**, with a corpus entry covering the case so it cannot
+  regress, and credit in the changelog unless you prefer otherwise.
+
+Since nothing is published yet there is no advisory or backport process to
+follow; once `sqld` is on the registry this section will be updated.


### PR DESCRIPTION
## What this changes

Fills out the five remaining items on the GitHub community standards checklist: code of conduct, contributing guidelines, security policy, issue templates, and a pull request template.

Written against how this repo actually works rather than as boilerplate:

- **`CONTRIBUTING.md`** — the `make` loop (`build` / `test` / `validate` / `validate-fast` / `sql` / `pg-stop`), and the corpus coverage rule its own section: add a `Sqld.Core` constructor → tagging functions go non-exhaustive → the coverage assertion fails until a corpus entry exists → referenced tables must be in `test/fixtures/schema.sql`. Also notes `EXAMPLES.md` is generated from the cookbook, and records the gitmoji commit convention.
- **`SECURITY.md`** — draws the line for a builder that never executes anything. Unparameterised literals, identifiers escaping their quotes, and param-numbering bugs are vulnerabilities; `raw` emitting what you passed it and `formatInline` substituting values are documented behaviour, not bugs.
- **`.github/ISSUE_TEMPLATE/`** — bug form asks for the `Query`, the emitted SQL/params, and whether PostgreSQL accepts it (pointing at `make sql`). Feature form asks whether `raw` already covers it. `config.yml` routes questions to Discussions and security reports to a private advisory.
- **`.github/pull_request_template.md`** — checklist mirrors CI.
- **`README.md`** — short Contributing section linking the three docs.

## SQL before / after

No change to emitted SQL — documentation and repository metadata only.

## Checklist

- [ ] `make validate` passes locally (tests **and** replay against PostgreSQL)
- [ ] New `Sqld.Core` constructors have a `test/Sqld/Corpus.purs` entry
- [ ] Any new tables/columns exist in `test/fixtures/schema.sql`
- [ ] `make examples-check` passes, or `EXAMPLES.md` was regenerated via `make examples`
- [ ] `CHANGELOG.md` updated under `[Unreleased]`

None of the above apply — no PureScript, corpus, or fixture changes in this PR. CI still runs the full suite against the unchanged source.

## Notes for the reviewer

- The community-standards checkmarks only appear once this is on `main`, since GitHub reads the default branch for that checklist.
- The code of conduct is Contributor Covenant 2.1 verbatim, with the enforcement contact set to petelooney81@gmail.com. Same address in `SECURITY.md` — worth confirming that is the one you want listed publicly.
- `config.yml` links to the Discussions tab and to the private security advisory form; both should resolve, but worth clicking once after merge.
- The three issue YAML files parse as valid YAML, but GitHub validates its own form schema on push — worth a glance at the "New issue" page after merge.
- `SECURITY.md` says the project is pre-1.0 and unpublished, and that only `main` gets fixes. That will need revisiting when `sqld` lands on the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)