### PR TITLE
:recycle: A `Keyword` class for the AST's context-free keyword tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/pg-validate-local.sh` — local runs against a throwaway Docker PostgreSQL container
 - `Makefile` — `make validate`, `validate-fast`, `sql`, `list`, `pg-stop`, and a self-documenting `make help`
 - CI runs the harness against a `postgres:16` service container on every push and pull request
+- `class Keyword a where keyword :: a -> String` in `Sqld.Core` — the fixed SQL keyword a value renders as, with instances for `SetOp`, `JoinType`, `OrderDir`, `FrameMode` and `FrameBound`, each beside the type it belongs to. Only for the AST's leaves: a keyword depends on nothing but the value, so anything whose rendering varies with layout, bindings or position stays in `Sqld.Format`. The instances are exhaustive, so a new constructor on any of the five is still a compile error
 
 ### Changed
 - `col` splits on a dot, so `col "u.id"` is `tcol "u" "id"` and renders `"u"."id"`. Previously the whole string was quoted as a single identifier, which produced SQL PostgreSQL rejects — two golden tests were asserting exactly that, green, because they were never in the validation corpus. `tcol` and `colRef` never split, for identifiers that genuinely contain a dot
@@ -69,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `select` is now additive — calling it multiple times appends to the select list rather than replacing it
 - Table aliases now render with explicit `AS` keyword (`FROM "users" AS "u"` instead of `FROM "users" "u"`)
 - Implicit `SELECT *` removed — use `select [star]` explicitly
+- `setOpKeyword`, `frameModeKeyword` and `formatFrameBound` removed from `Sqld.Format` in favour of the `Keyword` instances in `Sqld.Core`; the module has no export list, so they were public. The inline `case` expressions that spelled out the `JoinType` and `OrderDir` keywords inside `formatJoin` and `formatOrderExpr` go the same way. No emitted SQL changes
 
 ### Fixed
 - `formatPretty` breaks nested subqueries across lines instead of collapsing them onto one. A scalar subquery, `IN (SELECT …)`, `EXISTS (…)` or derived table now gets an indented block of its own, one level per level of nesting — which is the case pretty-printing exists for. Layout is threaded through the formatter as a `Layout` (`Inline` or `Pretty depth`) rather than a bare separator string, so `formatExpr` and `formatRelation` take an extra argument; `format` and `formatInline` are byte-for-byte unchanged, and only whitespace differs in what `formatPretty` emits. Indent width is fixed at two spaces by design

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ would reject, fails CI. Run them yourself with `spago run`.
 
 | Module | Contents |
 |---|---|
-| `Sqld.Core` | Core types: `Query`, `Expr`, `Literal`, `SelectExpr`, `Distinct`, `Cte`, `SetOperation`, `Window`, `emptyQuery`, `emptyWindow` |
+| `Sqld.Core` | Core types: `Query`, `Expr`, `Literal`, `SelectExpr`, `Distinct`, `Cte`, `SetOperation`, `Window`, `emptyQuery`, `emptyWindow`, `Keyword` |
 | `Sqld.Expr` | Expression helpers over the generic AST nodes — operators, literals, functions, subqueries |
 | `Sqld.Select` | SELECT query builders and select-list helpers |
 | `Sqld.Format` | `format`, `formatInline`, `formatPretty` |

--- a/src/Sqld/Core.purs
+++ b/src/Sqld/Core.purs
@@ -3,6 +3,14 @@ module Sqld.Core where
 import Prelude
 import Data.Maybe (Maybe(..))
 
+-- | The fixed SQL keyword a value renders as.
+-- |
+-- | Only for the AST's leaves: a keyword depends on nothing but the value —
+-- | no layout, no bindings, and no dependence on where it appears. Anything
+-- | whose rendering varies with context belongs in `Sqld.Format`.
+class Keyword a where
+  keyword :: a -> String
+
 type ColumnRef = { table :: Maybe String, column :: String }
 
 -- | Anything that can appear in `FROM` or as a join target.
@@ -79,6 +87,12 @@ data JoinType
   | RightJoin
   | FullJoin
 
+instance Keyword JoinType where
+  keyword InnerJoin = "JOIN"
+  keyword LeftJoin  = "LEFT JOIN"
+  keyword RightJoin = "RIGHT JOIN"
+  keyword FullJoin  = "FULL JOIN"
+
 type Join =
   { type_     :: JoinType
   , relation  :: Relation
@@ -86,6 +100,10 @@ type Join =
   }
 
 data OrderDir = Asc | Desc
+
+instance Keyword OrderDir where
+  keyword Asc  = "ASC"
+  keyword Desc = "DESC"
 
 type OrderExpr = { expr :: Expr, dir :: OrderDir }
 
@@ -114,6 +132,11 @@ data FrameMode
   | Range
   | Groups
 
+instance Keyword FrameMode where
+  keyword Rows   = "ROWS"
+  keyword Range  = "RANGE"
+  keyword Groups = "GROUPS"
+
 -- | One end of a frame.
 -- |
 -- | The offsets are emitted literally rather than as parameters, which keeps a
@@ -126,6 +149,15 @@ data FrameBound
   | CurrentRow
   | Following Int
   | UnboundedFollowing
+
+-- | Not a pure lookup — `Preceding` and `Following` carry an offset — but the
+-- | result still depends on nothing but the value.
+instance Keyword FrameBound where
+  keyword UnboundedPreceding = "UNBOUNDED PRECEDING"
+  keyword (Preceding n)      = show n <> " PRECEDING"
+  keyword CurrentRow         = "CURRENT ROW"
+  keyword (Following n)      = show n <> " FOLLOWING"
+  keyword UnboundedFollowing = "UNBOUNDED FOLLOWING"
 
 -- | Which rows of the partition a window function sees:
 -- | `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`, and its kin.
@@ -168,6 +200,11 @@ data SetOp
   | Except
 
 derive instance Eq SetOp
+
+instance Keyword SetOp where
+  keyword Union     = "UNION"
+  keyword Intersect = "INTERSECT"
+  keyword Except    = "EXCEPT"
 
 -- | Two result sets combined: `left UNION right`, and so on.
 -- |

--- a/src/Sqld/Format.purs
+++ b/src/Sqld/Format.purs
@@ -7,7 +7,7 @@ import Data.Maybe (Maybe(..), maybe)
 import Data.Monoid (power)
 import Data.String as String
 import Data.Tuple (Tuple(..))
-import Sqld.Core (Cte(..), Distinct(..), Expr(..), FormattedQuery, Frame, FrameBound(..), FrameMode(..), Join, JoinType(..), Literal(..), OrderDir(..), OrderExpr, Query, Relation(..), SelectExpr(..), SetOp(..), SetOperation(..), Window)
+import Sqld.Core (class Keyword, keyword, Cte(..), Distinct(..), Expr(..), FormattedQuery, Frame, Join, Literal(..), OrderExpr, Query, Relation(..), SelectExpr(..), SetOperation(..), Window)
 
 -- ---------------------------------------------------------------------------
 -- State threading — pure, no Effect
@@ -154,10 +154,10 @@ formatSelectBody layout q state0 = Tuple sql s6
 -- | `ORDER BY` and `LIMIT` of its own.
 formatSetOperation :: Layout -> SetOperation -> WithBindings String
 formatSetOperation layout (SetOperation so) state =
-  Tuple (leftSql <> sep <> keyword <> sep <> rightSql) s2
+  Tuple (leftSql <> sep <> kw <> sep <> rightSql) s2
   where
-  sep     = clauseSep layout
-  keyword = setOpKeyword so.op <> if so.all then " ALL" else mempty
+  sep = clauseSep layout
+  kw  = keyword so.op <> if so.all then " ALL" else mempty
 
   Tuple leftSql  s1 = formatOperand layout so.left  state
   Tuple rightSql s2 = formatOperand layout so.right s1
@@ -167,11 +167,6 @@ formatOperand layout q state = Tuple (parenthesise layout sql) s'
   where
   Tuple sql s' = formatQuery (nest layout) q state
 
-setOpKeyword :: SetOp -> String
-setOpKeyword Union     = "UNION"
-setOpKeyword Intersect = "INTERSECT"
-setOpKeyword Except    = "EXCEPT"
-
 -- ---------------------------------------------------------------------------
 -- Clause formatters
 -- ---------------------------------------------------------------------------
@@ -180,9 +175,9 @@ setOpKeyword Except    = "EXCEPT"
 -- | entry makes the whole `WITH` recursive.
 formatWith :: Layout -> Array Cte -> WithBindings String
 formatWith _ [] state = Tuple mempty state
-formatWith layout ctes state = Tuple (keyword <> intercalate ("," <> clauseSep layout) parts) s'
+formatWith layout ctes state = Tuple (kw <> intercalate ("," <> clauseSep layout) parts) s'
   where
-  keyword = if any (\(Cte c) -> c.recursive) ctes then "WITH RECURSIVE " else "WITH "
+  kw = if any (\(Cte c) -> c.recursive) ctes then "WITH RECURSIVE " else "WITH "
 
   Tuple parts s' = mapAccum (formatCte layout) state ctes
 
@@ -251,11 +246,7 @@ formatJoins layout joins state = Tuple (intercalate (clauseSep layout) parts) s'
 formatJoin :: Layout -> Join -> WithBindings String
 formatJoin layout j state = Tuple (kw <> " " <> relSql <> " ON (" <> onSql <> ")") s2
   where
-  kw = case j.type_ of
-    InnerJoin -> "JOIN"
-    LeftJoin  -> "LEFT JOIN"
-    RightJoin -> "RIGHT JOIN"
-    FullJoin  -> "FULL JOIN"
+  kw = keyword j.type_
 
   -- Relation before condition: a derived join target's parameters appear
   -- earlier in the SQL than the ON clause's.
@@ -291,9 +282,7 @@ formatOrderExpr layout { expr, dir } state = Tuple (sql <> " " <> dirSql) s'
   where
   Tuple sql s' = formatExpr layout expr state
 
-  dirSql = case dir of
-    Asc  -> "ASC"
-    Desc -> "DESC"
+  dirSql = keyword dir
 
 formatLimit :: Maybe Int -> String
 formatLimit Nothing  = mempty
@@ -433,23 +422,11 @@ formatPartitionBy layout exprs state = Tuple ("PARTITION BY " <> intercalate ", 
 -- | Carries no bindings: a frame's offsets are literal integers, so there is
 -- | nothing here to parameterise.
 formatFrame :: Frame -> String
-formatFrame { mode, start, end } = frameModeKeyword mode <> " " <> boundsSql
+formatFrame { mode, start, end } = keyword mode <> " " <> boundsSql
   where
   boundsSql = case end of
-    Nothing -> formatFrameBound start
-    Just e  -> "BETWEEN " <> formatFrameBound start <> " AND " <> formatFrameBound e
-
-frameModeKeyword :: FrameMode -> String
-frameModeKeyword Rows   = "ROWS"
-frameModeKeyword Range  = "RANGE"
-frameModeKeyword Groups = "GROUPS"
-
-formatFrameBound :: FrameBound -> String
-formatFrameBound UnboundedPreceding = "UNBOUNDED PRECEDING"
-formatFrameBound (Preceding n)      = show n <> " PRECEDING"
-formatFrameBound CurrentRow         = "CURRENT ROW"
-formatFrameBound (Following n)      = show n <> " FOLLOWING"
-formatFrameBound UnboundedFollowing = "UNBOUNDED FOLLOWING"
+    Nothing -> keyword start
+    Just e  -> "BETWEEN " <> keyword start <> " AND " <> keyword e
 
 -- ---------------------------------------------------------------------------
 -- Helpers


### PR DESCRIPTION
## What this changes

Moves the five fixed-keyword tables out of `Sqld.Format` and onto the types they belong to, behind a `class Keyword a where keyword :: a -> String` in `Sqld.Core`. Pure refactor. Closes #33

## SQL before / after

No emitted SQL changes, in either formatter, at either layout — `spago test` passes with **no test edits**, and all 115 corpus queries still validate against PostgreSQL.

## What moved

| Type | Was | Now |
|---|---|---|
| `SetOp` | `setOpKeyword` | `instance Keyword SetOp` |
| `JoinType` | inline `case` in `formatJoin` | `instance Keyword JoinType` |
| `OrderDir` | inline `case` in `formatOrderExpr` | `instance Keyword OrderDir` |
| `FrameMode` | `frameModeKeyword` | `instance Keyword FrameMode` |
| `FrameBound` | `formatFrameBound` | `instance Keyword FrameBound` |

Each instance sits directly after the `data` declaration it belongs to, and each is exhaustive — a new constructor stays a compile error, which is what keeps the coverage ratchet honest. The two `case` expressions were the worst version of the problem: the `JoinType` keyword table was invisible unless you already knew to look inside `formatJoin`.

The class is only for the AST's leaves — a keyword depends on nothing but the value, with no layout, no bindings and no dependence on where it appears. `Sqld.Core` gains no imports: `show` for `FrameBound`'s offsets comes from the Prelude it already imports, and a keyword is a `String` rather than a formatting decision, so this does not make `Core` depend on `Format`.

## Checklist

- [x] `make validate` passes locally — 250/250 golden tests, then 115 passed / 0 warned / 0 failed against PostgreSQL
- [x] New `Sqld.Core` constructors have a `test/Sqld/Corpus.purs` entry — n/a, no new constructors
- [x] Any new tables/columns exist in `test/fixtures/schema.sql` — n/a
- [x] `make examples-check` passes
- [x] `CHANGELOG.md` updated under `[Unreleased]`

## Notes for the reviewer

**Two renames that aren't cosmetic.** `Sqld.Format` already bound `keyword` locally twice. `formatSetOperation` breaks outright once the class method is imported — its own right-hand side needs `keyword so.op`, which would resolve to the `String` being defined. `formatWith` gains nothing from this issue (`WITH` / `WITH RECURSIVE` is a property of the clause, not of a type), but leaving a local `keyword` shadowing the class method is exactly the confusion the class is meant to remove. Both are now `kw`.

**The import list shrank.** With the tables gone, `FrameBound(..)`, `FrameMode(..)`, `JoinType(..)`, `OrderDir(..)` and `SetOp(..)` were unreferenced in `Format` — those constructors were only ever matched by the deleted functions. Dropped from the import rather than left as five warnings; the module now builds clean.

**Breaking, technically.** `setOpKeyword`, `frameModeKeyword` and `formatFrameBound` are removed, and `Sqld.Format` has no export list, so they were public. Logged under **Changed** rather than Added for that reason.

**A `Format` class for the whole AST was considered and rejected** — see *Out of scope* on #33. Several types render differently depending on where they appear (`Array Expr` is a `GROUP BY` list, a `PARTITION BY` list, a bracketed `DISTINCT ON (…)` and a parenthesised `Row`), and one instance per type cannot say that without a newtype per context or a mode argument that is `Layout` under another name. The corpus tag functions in `test/Sqld/Corpus.purs` look like the same table and are deliberately untouched: they name AST constructors for the ratchet, not SQL, and the ratchet is worth more written independently of the code it checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)